### PR TITLE
Add project grid and responsive styles

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -95,6 +95,7 @@
       { name: "Hamamatsucho",   mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/hamamatsucho-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Hamamatsucho.mp3" },
       { name: "Shimbashi",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shimbashi-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shimbashi.mp3" },
       { name: "Yurakucho",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/yurakucho-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Yurakucho.mp3" }
+      ,{ name: "Tokyo",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tokyo-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tokyo.mp3" }
     ];
     
     let currentStationIndex = -1;

--- a/index.html
+++ b/index.html
@@ -10,10 +10,14 @@
 
   <h1>Made With Only AI</h1>
   <p class="intro-text">I dont know how to code, and i dont know how to make a website, everything here including this has been made using only AI</p>
-  <!-- Button that navigates to ./Sites/yamanoteline/index.html -->
-  <button class="ai-button" onclick="window.location.href='./Sites/yamanoteline/index.html'">
-    Go to Yamanote Line
-  </button>
+
+  <div class="project-grid">
+    <a class="project-card" href="./Sites/yamanoteline/index.html">
+      <img src="https://via.placeholder.com/150" alt="Yamanote Line thumbnail" />
+      <h3>Yamanote Line</h3>
+      <p>A visualization of Tokyo's Yamanote train line with station announcements.</p>
+    </a>
+  </div>
 
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -13,8 +13,9 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  min-height: 100vh;
   text-align: center;
+  padding: 1rem;
 }
 
 /* Main title styling */
@@ -59,4 +60,39 @@ h3 {
   line-height: 1.5;
   margin: 20px 0;
   text-align: center;
+}
+
+/* Grid of projects */
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  width: 100%;
+  max-width: 1000px;
+}
+
+.project-card {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.project-card img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .project-grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- list available projects in a grid on the homepage
- style grid and project cards with responsive CSS
- fix Yamanote Line data to include 30th station so tests pass

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847f96cc9e48328a47de303906d8bac