### PR TITLE
Add modern layout toggle for Yamanote line demo

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -6,6 +6,7 @@
   <!-- Basic Content Security Policy -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="layout-modern.css">
 </head>
 <body>
   <!-- Circle wrapper for arrows and station labels -->
@@ -54,6 +55,7 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <button id="layoutToggle" class="layout-button">Switch Layout</button>
     </div>
   </div>
 

--- a/Sites/yamanoteline/layout-modern.css
+++ b/Sites/yamanoteline/layout-modern.css
@@ -1,0 +1,46 @@
+/* Modern grid layout for Yamanote line */
+
+body.modern-layout #arrowContainer {
+  display: none;
+}
+
+body.modern-layout #circleWrapper {
+  width: 100%;
+  height: auto;
+  margin: 20px auto;
+  max-width: 800px;
+}
+
+body.modern-layout #stations {
+  position: static;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 10px;
+  padding: 20px;
+}
+
+body.modern-layout .station {
+  position: static;
+  transform: none;
+  text-align: center;
+}
+
+/* Layout toggle button */
+#layoutToggle.layout-button {
+  background: none;
+  border: 1px solid #91c73e;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.9em;
+  cursor: pointer;
+  color: #91c73e;
+}
+
+#layoutToggle.layout-button:hover {
+  background-color: #e0f0c0;
+}
+
+body.dark-mode #layoutToggle.layout-button {
+  color: #ccc;
+  border-color: #888;
+}

--- a/Sites/yamanoteline/main.js
+++ b/Sites/yamanoteline/main.js
@@ -47,6 +47,7 @@
     const directionText = document.getElementById("directionText");
     const darkModeToggle = document.getElementById("darkModeToggle");
     const darkModeText = document.getElementById("darkModeText");
+    const layoutToggle = document.getElementById("layoutToggle");
     const playPauseBtn = document.getElementById("playPauseBtn");
 
     // Dark mode toggle
@@ -57,6 +58,36 @@
       } else {
         document.body.classList.remove("dark-mode");
         darkModeText.textContent = "Light Mode";
+      }
+    });
+
+    // Layout toggle button
+    layoutToggle.addEventListener("click", () => {
+      if (document.body.classList.contains("modern-layout")) {
+        document.body.classList.remove("modern-layout");
+        layoutToggle.textContent = "Switch Layout";
+        localStorage.setItem("layout", "classic");
+        // Reposition stations for circle layout
+        placeStations();
+        generateArrows();
+        updateArrowAnimation();
+      } else {
+        document.body.classList.add("modern-layout");
+        layoutToggle.textContent = "Classic Layout";
+        localStorage.setItem("layout", "modern");
+        // Clear arrows when in modern layout
+        document.getElementById("arrowContainer").innerHTML = "";
+        // Rebuild station list without positioning
+        const stationsContainer = document.getElementById("stations");
+        stationsContainer.innerHTML = "";
+        stations.forEach((st, i) => {
+          const div = document.createElement("div");
+          div.classList.add("station");
+          div.textContent = st.name;
+          div.dataset.index = i;
+          div.addEventListener("click", () => playStation(i));
+          stationsContainer.appendChild(div);
+        });
       }
     });
 
@@ -255,7 +286,25 @@
 
     // On window load
     window.onload = function() {
-      generateArrows();
-      updateArrowAnimation();
-      placeStations();
+      const savedLayout = localStorage.getItem("layout");
+      if (savedLayout === "modern") {
+        document.body.classList.add("modern-layout");
+        layoutToggle.textContent = "Classic Layout";
+        // Build grid layout
+        document.getElementById("arrowContainer").innerHTML = "";
+        const stationsContainer = document.getElementById("stations");
+        stations.forEach((st, i) => {
+          const div = document.createElement("div");
+          div.classList.add("station");
+          div.textContent = st.name;
+          div.dataset.index = i;
+          div.addEventListener("click", () => playStation(i));
+          stationsContainer.appendChild(div);
+        });
+      } else {
+        layoutToggle.textContent = "Switch Layout";
+        generateArrows();
+        updateArrowAnimation();
+        placeStations();
+      }
     };


### PR DESCRIPTION
## Summary
- add new `layout-modern.css` for grid layout of stations
- provide layout switch button in page
- implement layout switching logic in `main.js`
- remember layout preference using localStorage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fc2f4dbc83288e2ba29af48c19d7