### PR TITLE
Add viewport meta tags for responsive layout

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Yamanote Line - Stations on Circle with Dark Mode</title>
   <!-- Basic Content Security Policy -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Made With Only AI</title>
   <!-- Link to your external CSS file -->
   <link rel="stylesheet" href="styles.css" />


### PR DESCRIPTION
## Summary
- add viewport meta tags to ensure responsive scaling on main page and Yamanote Line page

## Testing
- `pytest`
- `npx playwright screenshot --device="iPhone 13" index.html index-mobile.png`
- `npx playwright screenshot --device="iPhone 13" Sites/yamanoteline/index.html yamanoteline-mobile.png`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0f69b9c8328b46b7da78ab9cd1e