### PR TITLE
Add station, nature, urban, and nightlife sound sections

### DIFF
--- a/Sites/go-to-japan-sounds/index.html
+++ b/Sites/go-to-japan-sounds/index.html
@@ -17,6 +17,28 @@
   <main>
     <input type="text" id="searchInput" placeholder="Search sounds..." />
 
+    <section class="category" data-category="Stations">
+      <h2>Stations</h2>
+      <div class="sounds-grid">
+        <div class="sound-card" data-name="Tokyo Station">
+          <p>Tokyo Station</p>
+          <audio controls src="../yamanoteline/sounds/Tokyo.mp3"></audio>
+        </div>
+        <div class="sound-card" data-name="Shinjuku Station">
+          <p>Shinjuku Station</p>
+          <audio controls src="../yamanoteline/sounds/Shinjuku.mp3"></audio>
+        </div>
+        <div class="sound-card" data-name="Shibuya Station">
+          <p>Shibuya Station</p>
+          <audio controls src="../yamanoteline/sounds/Shibuya.mp3"></audio>
+        </div>
+        <div class="sound-card" data-name="Akihabara Station">
+          <p>Akihabara Station</p>
+          <audio controls src="../yamanoteline/sounds/Akihabara.mp3"></audio>
+        </div>
+      </div>
+    </section>
+
     <section class="category" data-category="Nature">
       <h2>Nature</h2>
       <div class="sounds-grid">
@@ -28,33 +50,41 @@
           <p>Forest Ambience</p>
           <audio controls src="../yamanoteline/sounds/Mejiro.mp3"></audio>
         </div>
+        <div class="sound-card" data-name="Park Birds">
+          <p>Park Birds</p>
+          <audio controls src="../yamanoteline/sounds/Yoyogi.mp3"></audio>
+        </div>
       </div>
     </section>
 
     <section class="category" data-category="Urban">
       <h2>Urban</h2>
       <div class="sounds-grid">
-        <div class="sound-card" data-name="Shinjuku Station">
-          <p>Shinjuku Station</p>
-          <audio controls src="../yamanoteline/sounds/Shinjuku.mp3"></audio>
+        <div class="sound-card" data-name="Ikebukuro Downtown">
+          <p>Ikebukuro Downtown</p>
+          <audio controls src="../yamanoteline/sounds/Ikebukuro.mp3"></audio>
         </div>
-        <div class="sound-card" data-name="Shibuya Crossing">
-          <p>Shibuya Crossing</p>
-          <audio controls src="../yamanoteline/sounds/Shibuya.mp3"></audio>
+        <div class="sound-card" data-name="Shinagawa Traffic">
+          <p>Shinagawa Traffic</p>
+          <audio controls src="../yamanoteline/sounds/Shinagawa.mp3"></audio>
+        </div>
+        <div class="sound-card" data-name="Ueno Market">
+          <p>Ueno Market</p>
+          <audio controls src="../yamanoteline/sounds/Ueno.mp3"></audio>
         </div>
       </div>
     </section>
 
-    <section class="category" data-category="Cultural">
-      <h2>Cultural</h2>
+    <section class="category" data-category="Nightlife">
+      <h2>Nightlife</h2>
       <div class="sounds-grid">
-        <div class="sound-card" data-name="Festival Drums">
-          <p>Festival Drums</p>
-          <audio controls src="../yamanoteline/sounds/Ebisu.mp3"></audio>
+        <div class="sound-card" data-name="Shimbashi Nightlife">
+          <p>Shimbashi Nightlife</p>
+          <audio controls src="../yamanoteline/sounds/Shimbashi.mp3"></audio>
         </div>
-        <div class="sound-card" data-name="Tea Ceremony">
-          <p>Tea Ceremony</p>
-          <audio controls src="../yamanoteline/sounds/Kanda.mp3"></audio>
+        <div class="sound-card" data-name="Ebisu Nights">
+          <p>Ebisu Nights</p>
+          <audio controls src="../yamanoteline/sounds/Ebisu.mp3"></audio>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Replace previous categories with four sections: Stations, Nature, Urban, and Nightlife, each filled with representative sound cards using available Yamanote Line audio clips.
- Verified search script still targets `.category` elements so it works with the new structure.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a98518108328ba9d7963852710c2