### PR TITLE
Add TCG card collection tracker site

### DIFF
--- a/Sites/tcg-tracker/app.js
+++ b/Sites/tcg-tracker/app.js
@@ -1,0 +1,103 @@
+async function searchCard() {
+  const query = document.getElementById('search').value.trim();
+  if (!query) return;
+
+  try {
+    const cardResp = await fetch(`https://api.scryfall.com/cards/named?fuzzy=${encodeURIComponent(query)}`);
+    if (!cardResp.ok) throw new Error('Card not found');
+    const card = await cardResp.json();
+
+    let next = card.prints_search_uri;
+    let variants = [];
+    while (next) {
+      const resp = await fetch(next);
+      const data = await resp.json();
+      variants = variants.concat(data.data);
+      next = data.has_more ? data.next_page : null;
+    }
+
+    displayVariants(variants);
+  } catch (err) {
+    alert(err.message);
+  }
+}
+
+function displayVariants(variants) {
+  const container = document.getElementById('variants');
+  container.innerHTML = '';
+
+  variants.forEach(v => {
+    if (!v.image_uris) return; // skip cards without images
+    const cardDiv = document.createElement('div');
+    cardDiv.className = 'card';
+
+    const img = document.createElement('img');
+    img.src = v.image_uris.small;
+    img.alt = v.name;
+
+    const title = document.createElement('h3');
+    title.textContent = `${v.name} (${v.set.toUpperCase()})`;
+
+    const btn = document.createElement('button');
+    btn.textContent = 'Add to Collection';
+    btn.addEventListener('click', () => addToCollection(v));
+
+    cardDiv.append(img, title, btn);
+    container.appendChild(cardDiv);
+  });
+}
+
+function addToCollection(card) {
+  let collection = JSON.parse(localStorage.getItem('collection') || '[]');
+  if (!collection.find(c => c.id === card.id)) {
+    collection.push({
+      id: card.id,
+      name: card.name,
+      set: card.set_name,
+      image: card.image_uris ? card.image_uris.small : ''
+    });
+    localStorage.setItem('collection', JSON.stringify(collection));
+    renderCollection();
+  }
+}
+
+function renderCollection() {
+  const list = document.getElementById('collectionList');
+  list.innerHTML = '';
+  const collection = JSON.parse(localStorage.getItem('collection') || '[]');
+
+  collection.forEach(item => {
+    const li = document.createElement('li');
+    li.className = 'collection-item';
+
+    const img = document.createElement('img');
+    img.src = item.image;
+    img.alt = item.name;
+
+    const span = document.createElement('span');
+    span.textContent = `${item.name} (${item.set})`;
+
+    const btn = document.createElement('button');
+    btn.textContent = '\u00d7';
+    btn.addEventListener('click', () => removeFromCollection(item.id));
+
+    li.append(img, span, btn);
+    list.appendChild(li);
+  });
+}
+
+function removeFromCollection(id) {
+  let collection = JSON.parse(localStorage.getItem('collection') || '[]');
+  collection = collection.filter(c => c.id !== id);
+  localStorage.setItem('collection', JSON.stringify(collection));
+  renderCollection();
+}
+
+// Event listeners
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('searchBtn').addEventListener('click', searchCard);
+  document.getElementById('search').addEventListener('keypress', e => {
+    if (e.key === 'Enter') searchCard();
+  });
+  renderCollection();
+});

--- a/Sites/tcg-tracker/index.html
+++ b/Sites/tcg-tracker/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TCG Collection Tracker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>TCG Collection Tracker</h1>
+    <div id="search-container">
+      <input type="text" id="search" placeholder="Search for a card..." />
+      <button id="searchBtn">Search</button>
+    </div>
+  </header>
+  <main>
+    <section id="variants" class="card-grid"></section>
+    <section id="collection">
+      <h2>My Collection</h2>
+      <ul id="collectionList" class="card-grid"></ul>
+    </section>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/Sites/tcg-tracker/style.css
+++ b/Sites/tcg-tracker/style.css
@@ -1,0 +1,112 @@
+/* Dark sleek theme */
+:root {
+  --bg: #1a1a1a;
+  --fg: #f0f0f0;
+  --accent: #4a90e2;
+  --danger: #e74c3c;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+header {
+  text-align: center;
+  padding: 1rem;
+  background: #111;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+#search-container {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+#search {
+  width: 60%;
+  max-width: 400px;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 4px 0 0 4px;
+}
+
+#searchBtn {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: var(--accent);
+  color: var(--fg);
+  border-radius: 0 4px 4px 0;
+  cursor: pointer;
+}
+
+main {
+  padding: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #222;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  text-align: center;
+}
+
+.card img {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.card button {
+  margin-top: 0.5rem;
+  width: 100%;
+  padding: 0.5rem;
+  background: var(--accent);
+  color: var(--fg);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#collection h2 {
+  margin: 2rem 0 1rem 0;
+}
+
+.collection-item {
+  background: #222;
+  border-radius: 8px;
+  padding: 0.5rem;
+  position: relative;
+}
+
+.collection-item img {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.collection-item span {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.collection-item button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--danger);
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -20,5 +20,9 @@
     Go to Japan Sounds
   </button>
 
+  <button class="ai-button" onclick="window.location.href='./Sites/tcg-tracker/index.html'">
+    Go to TCG Tracker
+  </button>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add new TCG Tracker site to manage a personal card collection and view all card printings.
- Implement sleek dark theme and local storage integration for tracking owned variants.
- Link tracker from project home page.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a314f7548328b16cd399693c2865