### PR TITLE
Add Riftbound card collection tracker

### DIFF
--- a/Sites/tcg-tracker/app.js
+++ b/Sites/tcg-tracker/app.js
@@ -1,0 +1,37 @@
+const DATA_URL = 'https://raw.githubusercontent.com/Somberlord/riftboundfaq/refs/heads/main/app/data/sets/OGN.json';
+const STORAGE_KEY = 'riftboundCollection';
+
+async function init() {
+  const res = await fetch(DATA_URL);
+  const data = await res.json();
+  const cards = data.items;
+  const container = document.getElementById('cards');
+  const statsEl = document.getElementById('stats');
+  let owned = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+
+  function updateStats() {
+    const total = cards.length;
+    const collected = Object.values(owned).filter(Boolean).length;
+    const percent = ((collected / total) * 100).toFixed(1);
+    statsEl.textContent = `Collected ${collected} / ${total} cards (${percent}%)`;
+  }
+
+  cards.forEach(card => {
+    const div = document.createElement('div');
+    div.className = 'card';
+    div.textContent = card.title;
+    if (owned[card.id]) div.classList.add('collected');
+    div.addEventListener('click', () => {
+      owned[card.id] = !owned[card.id];
+      if (owned[card.id]) div.classList.add('collected');
+      else div.classList.remove('collected');
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(owned));
+      updateStats();
+    });
+    container.appendChild(div);
+  });
+
+  updateStats();
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/Sites/tcg-tracker/index.html
+++ b/Sites/tcg-tracker/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Riftbound Card Tracker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Riftbound Card Tracker</h1>
+    <div id="stats">Loading...</div>
+  </header>
+  <main id="cards" class="card-grid"></main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/Sites/tcg-tracker/style.css
+++ b/Sites/tcg-tracker/style.css
@@ -1,0 +1,47 @@
+:root {
+  --bg: #1a1a1a;
+  --fg: #f0f0f0;
+  --accent: #4a90e2;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+header {
+  text-align: center;
+  padding: 1rem;
+  background: #111;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+#stats {
+  margin-top: 0.5rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+.card {
+  background: #2a2a2a;
+  border-radius: 6px;
+  padding: 0.5rem;
+  text-align: center;
+  cursor: pointer;
+  filter: grayscale(100%);
+  color: #888;
+  transition: filter 0.3s, color 0.3s;
+}
+
+.card.collected {
+  filter: none;
+  color: var(--fg);
+  background: #333;
+}

--- a/index.html
+++ b/index.html
@@ -20,5 +20,9 @@
     Go to Japan Sounds
   </button>
 
+  <button class="ai-button" onclick="window.location.href='./Sites/tcg-tracker/index.html'">
+    Go to Riftbound Tracker
+  </button>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace generic TCG tracker with Riftbound card collection tracker loaded from community dataset
- Display collection stats and toggle cards between grey and color when collected
- Link tracker from project home page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a314f7548328b16cd399693c2865