### PR TITLE
Ensure station announcements load from bundled assets

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -3,66 +3,86 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Yamanote Line - Stations on Circle with Dark Mode</title>
-  <!-- Basic Content Security Policy -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
+  <title>Yamanote Line Immersive Guide</title>
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; img-src 'self' data: https://images.unsplash.com https://media.timeout.com https://upload.wikimedia.org https://cdn.pixabay.com; media-src 'self' https://madewithonlyai.com https://cdn.pixabay.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; script-src 'self'; connect-src 'self';">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="layout-modern.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <!-- Circle wrapper for arrows and station labels -->
-  <div id="circleWrapper">
-    <div id="arrowContainer"></div>
-    <div id="stations"></div>
+  <div id="app" class="app">
+    <header class="top-bar">
+      <button id="mapToggle" class="ghost-button" aria-expanded="false">Map</button>
+      <div class="search-wrapper">
+        <label class="sr-only" for="stationSearch">Search stations</label>
+        <input id="stationSearch" list="stationList" type="search" placeholder="Search stations…" autocomplete="off">
+        <datalist id="stationList"></datalist>
+        <button id="jumpButton" class="ghost-button">Go</button>
+      </div>
+      <div class="top-actions">
+        <button id="rideModeButton" class="ghost-button" aria-pressed="true">Ride Mode On</button>
+        <button id="ambientToggle" class="ghost-button" aria-pressed="false">Ambient Off</button>
+      </div>
+    </header>
+
+    <main id="stationViewport" class="station-viewport" tabindex="0">
+      <div id="stationBackground" class="station-background" role="img" aria-live="polite"></div>
+      <div class="station-overlay"></div>
+
+      <div id="prevStationPreview" class="station-preview station-preview--previous" aria-hidden="true"></div>
+      <div id="nextStationPreview" class="station-preview station-preview--next" aria-hidden="true"></div>
+
+      <section class="station-content">
+        <div class="station-name">
+          <span id="stationNameJp" class="station-name__jp" lang="ja"></span>
+          <span id="stationNameEn" class="station-name__en"></span>
+        </div>
+        <article class="station-info">
+          <h2 class="station-info__heading">About this station</h2>
+          <p id="stationAbout"></p>
+        </article>
+        <section class="transfer-lines" aria-label="Transfer lines">
+          <h3 class="transfer-lines__heading">Transfers</h3>
+          <div id="transferLines" class="transfer-lines__list"></div>
+        </section>
+      </section>
+
+      <div class="audio-panel" role="region" aria-label="Station announcements">
+        <div class="audio-panel__primary">
+          <button id="playPause" class="control-button" aria-pressed="false">▶</button>
+          <button id="skipStation" class="control-button" aria-label="Skip to next station">⏭</button>
+          <div class="volume-control">
+            <label for="volumeSlider">Volume</label>
+            <input id="volumeSlider" type="range" min="0" max="1" step="0.01">
+          </div>
+        </div>
+        <div class="audio-panel__secondary">
+          <span id="currentTrackLabel" class="track-label"></span>
+          <button id="muteButton" class="ghost-button" aria-pressed="false">Mute</button>
+        </div>
+      </div>
+
+      <nav class="mobile-dock" aria-label="Mobile controls">
+        <button id="mobilePlay" class="dock-button" aria-pressed="false">▶</button>
+        <button id="mobileSkip" class="dock-button" aria-label="Skip to next">⏭</button>
+        <button id="mobileMap" class="dock-button" aria-expanded="false">Map</button>
+      </nav>
+    </main>
+
+    <aside id="mapOverlay" class="map-overlay" aria-hidden="true">
+      <div class="map-overlay__inner">
+        <button id="closeMap" class="ghost-button map-overlay__close" aria-label="Close map">×</button>
+        <h2>Yamanote Loop</h2>
+        <svg id="loopMap" viewBox="0 0 1400 400" role="img" aria-label="Interactive map of the Yamanote Line"></svg>
+      </div>
+    </aside>
   </div>
 
-  <!-- Audio bar at the bottom (single horizontal row) -->
-  <div id="audioPlayer">
-    <div class="left-controls">
-      <div class="volume-control">
-        <span class="volume-label">Announcement</span>
-        <button class="volume-icon" id="announcementVolumeIcon">🔊</button>
-        <input type="range" id="announcementVolumeSlider" min="0" max="1" step="0.01" value="1">
-      </div>
-      <div class="volume-control">
-        <span class="volume-label">Station</span>
-        <button class="volume-icon" id="stationVolumeIcon">🔊</button>
-        <input type="range" id="stationVolumeSlider" min="0" max="1" step="0.01" value="1">
-      </div>
-    </div>
-    <div class="center-controls">
-      <span id="currentStation">No station selected</span>
-      <button id="playPauseBtn" class="control-button">▶</button>
-    </div>
-    <div class="right-controls">
-      <div class="switch-control">
-        <span id="skipText">Skip Announcements</span>
-        <label class="switch">
-          <input type="checkbox" id="skipAnnouncement">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="switch-control">
-        <span id="directionText">Clockwise</span>
-        <label class="switch">
-          <input type="checkbox" id="directionToggle" checked>
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="switch-control">
-        <span id="darkModeText">Light Mode</span>
-        <label class="switch">
-          <input type="checkbox" id="darkModeToggle">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <button id="layoutToggle" class="layout-button">Switch Layout</button>
-    </div>
-  </div>
+  <audio id="announcementAudio" preload="auto" crossorigin="anonymous"></audio>
+  <audio id="ambientAudio" preload="auto" loop crossorigin="anonymous" src="https://cdn.pixabay.com/audio/2022/03/15/audio_54c178aeb5.mp3"></audio>
 
-  <!-- Hidden audio element for playback -->
-  <audio id="audio" preload="auto"></audio>
-
-  <script src="main.js"></script>
+  <script src="main.js" type="module"></script>
 </body>
 </html>

--- a/Sites/yamanoteline/main.js
+++ b/Sites/yamanoteline/main.js
@@ -1,311 +1,980 @@
-    // Cache busting query param
-    const cacheBust = "?v=1";
+const CACHE_BUST = '?v=202403';
 
-    // All 30 Yamanote stations
-    const stations = [
-      { name: "Tokyo",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tokyo-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tokyo.mp3" },
-      { name: "Kanda",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/kanda-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Kanda.mp3" },
-      { name: "Akihabara",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/akihabara-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Akihabara.mp3" },
-      { name: "Okachimachi",    mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/okachimachi-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Okachimachi.mp3" },
-      { name: "Ueno",           mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/ueno-announcement.mp3",        mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Ueno.mp3" },
-      { name: "Uguisudani",     mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/uguisudani-announcement.mp3",  mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Uguisudani.mp3" },
-      { name: "Nippori",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/nippori-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Nippori.mp3" },
-      { name: "Nishi-Nippori",  mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/nishinippori-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Nishinippori.mp3" },
-      { name: "Tabata",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tabata-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tabata.mp3" },
-      { name: "Komagome",       mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/komagome-announcement.mp3",    mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Komagome.mp3" },
-      { name: "Sugamo",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/sugamo-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Sugamo.mp3" },
-      { name: "Otsuka",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/otsuka-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Otsuka.mp3" },
-      { name: "Ikebukuro",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/ikebukuro-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Ikebukuro.mp3" },
-      { name: "Mejiro",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/mejiro-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Mejiro.mp3" },
-      { name: "Takadanobaba",   mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/takadanobaba-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Takadanobaba.mp3" },
-      { name: "Shin-Okubo",     mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shinokubo-announcement.mp3",  mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shinokubo.mp3" },
-      { name: "Shinjuku",       mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shinjuku-announcement.mp3",    mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shinjuku.mp3" },
-      { name: "Yoyogi",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/yoyogi-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Yoyogi.mp3" },
-      { name: "Harajuku",       mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/harajuku-announcement.mp3",    mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Harajuku.mp3" },
-      { name: "Shibuya",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shibuya-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shibuya.mp3" },
-      { name: "Ebisu",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/ebisu-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Ebisu.mp3" },
-      { name: "Meguro",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/meguro-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Meguro.mp3" },
-      { name: "Gotanda",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/gotanda-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Gotanda.mp3" },
-      { name: "Osaki",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/osaki-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Osaki.mp3" },
-      { name: "Shinagawa",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shinagawa-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shinagawa.mp3" },
-      { name: "Takanawa Gateway", mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/takanawagateway-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/TakanawaGateway.mp3" },
-      { name: "Tamachi",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tamachi-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tamachi.mp3" },
-      { name: "Hamamatsucho",   mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/hamamatsucho-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Hamamatsucho.mp3" },
-      { name: "Shimbashi",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shimbashi-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shimbashi.mp3" },
-      { name: "Yurakucho",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/yurakucho-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Yurakucho.mp3" }
-    ];
-    
-    let currentStationIndex = -1;
-    let announcementVolume = 1, stationVolume = 1;
-    let announcementMuted = false, stationMuted = false;
-    let currentAudioType = "";
-    let playDirection = 1; // +1 clockwise, -1 counterclockwise
+function resolveMediaPath(path) {
+  if (path.startsWith('Sites/')) {
+    return path.replace(/^Sites\/yamanoteline\//, '');
+  }
+  return path;
+}
 
-    const audioElement = document.getElementById("audio");
-    const currentStationLabel = document.getElementById("currentStation");
-    const skipAnnouncementToggle = document.getElementById("skipAnnouncement");
-    const directionToggle = document.getElementById("directionToggle");
-    const directionText = document.getElementById("directionText");
-    const darkModeToggle = document.getElementById("darkModeToggle");
-    const darkModeText = document.getElementById("darkModeText");
-    const layoutToggle = document.getElementById("layoutToggle");
-    const playPauseBtn = document.getElementById("playPauseBtn");
+function getAnnouncementSrc(station) {
+  return `${resolveMediaPath(station.mp3Announcement)}${CACHE_BUST}`;
+}
 
-    // Dark mode toggle
-    darkModeToggle.addEventListener("change", () => {
-      if (darkModeToggle.checked) {
-        document.body.classList.add("dark-mode");
-        darkModeText.textContent = "Dark Mode";
-      } else {
-        document.body.classList.remove("dark-mode");
-        darkModeText.textContent = "Light Mode";
-      }
-    });
+const stations = [
+  {
+    id: 'tokyo',
+    name: 'Tokyo',
+    japaneseName: '東京',
+    about:
+      'Tokyo Station anchors Japan\'s capital with its red-brick Marunouchi facade and bustling underground concourses. Marunouchi and Nihonbashi surround the hub with flagship stores, refined dining, and the Imperial Palace gardens just a short stroll away.',
+    background:
+      'https://images.unsplash.com/photo-1549692520-acc6669e2f0c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo Line (Rapid)', code: 'JC', color: '#f15a24', operator: 'JR East' },
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'Tokaido Shinkansen', code: '🚄', color: '#1b5e20', operator: 'JR Central' },
+      { name: 'Tokyo Metro Marunouchi Line', code: 'M', color: '#c62828', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/tokyo-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Tokyo.mp3"
+  },
+  {
+    id: 'kanda',
+    name: 'Kanda',
+    japaneseName: '神田',
+    about:
+      'Kanda blends old-world wholesalers with a growing tech crowd, filling the side streets with retro coffee shops and lively izakaya. Students from nearby universities keep the district energetic well into the night.',
+    background:
+      'https://images.unsplash.com/photo-1512455102795-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo Line (Rapid)', code: 'JC', color: '#f15a24', operator: 'JR East' },
+      { name: 'Tokyo Metro Ginza Line', code: 'G', color: '#f9a825', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/kanda-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Kanda.mp3"
+  },
+  {
+    id: 'akihabara',
+    name: 'Akihabara',
+    japaneseName: '秋葉原',
+    about:
+      'Electric Town dazzles with towering anime billboards, electronics megastores, and specialty game shops. From maid cafés to retro arcades, Akihabara celebrates subculture and tech innovation on every block.',
+    background:
+      'https://images.unsplash.com/photo-1518548419970-58e3b4079ab2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Sobu Line', code: 'JB', color: '#f6b27b', operator: 'JR East' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' },
+      { name: 'Tsukuba Express', code: 'TX', color: '#5c6bc0', operator: 'Metropolitan Intercity Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/akihabara-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Akihabara.mp3"
+  },
+  {
+    id: 'okachimachi',
+    name: 'Okachimachi',
+    japaneseName: '御徒町',
+    about:
+      'Okachimachi connects the open-air stalls of Ameya-Yokocho with polished jewelry boutiques under the tracks. The neighborhood\'s mix of street eats and craft workshops makes it a favorite for treasure hunters.',
+    background:
+      'https://images.unsplash.com/photo-1542051841857-5f90071e7989?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/okachimachi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Okachimachi.mp3"
+  },
+  {
+    id: 'ueno',
+    name: 'Ueno',
+    japaneseName: '上野',
+    about:
+      'Ueno is Tokyo\'s cultural commons, where national museums line the edges of Ueno Park and street food fills Ameyoko market. Springtime hanami crowds gather beneath the park\'s famous cherry blossoms.',
+    background:
+      'https://images.unsplash.com/photo-1503899036084-c55cdd92da26?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Utsunomiya Line', code: 'JU', color: '#f57c00', operator: 'JR East' },
+      { name: 'JR Joban Line', code: 'JJ', color: '#00796b', operator: 'JR East' },
+      { name: 'Tokyo Metro Ginza Line', code: 'G', color: '#f9a825', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' },
+      { name: 'Keisei Main Line', code: 'KS', color: '#1a73e8', operator: 'Keisei Electric Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/ueno-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Ueno.mp3"
+  },
+  {
+    id: 'uguisudani',
+    name: 'Uguisudani',
+    japaneseName: '鶯谷',
+    about:
+      'Named for the warbling nightingales once heard here, Uguisudani now offers quiet residential lanes beside small museums and Showa-era cafés. The gentle hillside views contrast with the bustle of nearby Ueno.',
+    background:
+      'https://images.unsplash.com/photo-1542038791-0d9df90f6a5a?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/uguisudani-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Uguisudani.mp3"
+  },
+  {
+    id: 'nippori',
+    name: 'Nippori',
+    japaneseName: '日暮里',
+    about:
+      'Nippori bridges tradition and creativity, with Yanaka\'s old temples on one side and the fabric district\'s rainbow bolts on the other. Travelers connect here to reach Narita via the Keisei Skyliner.',
+    background:
+      'https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'JR Joban Line', code: 'JJ', color: '#00796b', operator: 'JR East' },
+      { name: 'Keisei Skyliner', code: 'KS', color: '#1a73e8', operator: 'Keisei Electric Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/nippori-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Nippori.mp3"
+  },
+  {
+    id: 'nishi-nippori',
+    name: 'Nishi-Nippori',
+    japaneseName: '西日暮里',
+    about:
+      'Residential towers and neighborhood ramen counters define Nishi-Nippori. It is a convenient interchange linking the Chiyoda Line and the Nippori-Toneri Liner to Tokyo\'s northeastern suburbs.',
+    background:
+      'https://images.unsplash.com/photo-1517638851339-4aa32003c11a?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Chiyoda Line', code: 'C', color: '#009688', operator: 'Tokyo Metro' },
+      { name: 'Nippori-Toneri Liner', code: 'NT', color: '#43a047', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/nishinippori-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Nishinippori.mp3"
+  },
+  {
+    id: 'tabata',
+    name: 'Tabata',
+    japaneseName: '田端',
+    about:
+      'Tabata sits atop a ridge with long-established residential streets and views over the Sumida River rail yards. It is a practical stop for commuters heading toward Saitama and northern Tokyo.',
+    background:
+      'https://images.unsplash.com/photo-1566977744263-0bb0048e9b25?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/tabata-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Tabata.mp3"
+  },
+  {
+    id: 'komagome',
+    name: 'Komagome',
+    japaneseName: '駒込',
+    about:
+      'Komagome is famed for Rikugien Garden, a classical landscaped retreat glowing with autumn maples and spring azaleas. Shopping arcades by the station serve fresh wagashi and tea to strolling visitors.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Namboku Line', code: 'N', color: '#26a69a', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/komagome-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Komagome.mp3"
+  },
+  {
+    id: 'sugamo',
+    name: 'Sugamo',
+    japaneseName: '巣鴨',
+    about:
+      'Nicknamed the “Harajuku for grandmas,” Sugamo\'s Jizo-dori shopping street bustles with red underwear shops, sweets stalls, and pilgrims to Koganji Temple. Seasonal festivals keep the retro atmosphere lively.',
+    background:
+      'https://images.unsplash.com/photo-1529921879218-f9956cc87d77?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Toei Mita Line', code: 'I', color: '#1565c0', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/sugamo-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Sugamo.mp3"
+  },
+  {
+    id: 'otsuka',
+    name: 'Otsuka',
+    japaneseName: '大塚',
+    about:
+      'Otsuka mixes vintage tram charm with a wave of new cafés and craft beer bars. The Tokyo Sakura Tram still trundles past the station, connecting quiet residential pockets in northern Tokyo.',
+    background:
+      'https://images.unsplash.com/photo-1518378188025-22bd89516ee2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Sakura Tram (Toden Arakawa Line)', code: 'SA', color: '#ec407a', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/otsuka-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Otsuka.mp3"
+  },
+  {
+    id: 'ikebukuro',
+    name: 'Ikebukuro',
+    japaneseName: '池袋',
+    about:
+      'Ikebukuro is a mega terminal anchored by Sunshine City, anime boutiques, and rooftop observatories. West Gate Park and student-filled diners keep the area buzzing day and night.',
+    background:
+      'https://images.unsplash.com/photo-1528164344705-47542687000d?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Tokyo Metro Marunouchi Line', code: 'M', color: '#c62828', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Fukutoshin Line', code: 'F', color: '#6d4c41', operator: 'Tokyo Metro' },
+      { name: 'Seibu Ikebukuro Line', code: 'SI', color: '#2196f3', operator: 'Seibu Railway' },
+      { name: 'Tobu Tojo Line', code: 'TJ', color: '#ff7043', operator: 'Tobu Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/ikebukuro-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Ikebukuro.mp3"
+  },
+  {
+    id: 'mejiro',
+    name: 'Mejiro',
+    japaneseName: '目白',
+    about:
+      'Leafy Mejiro is defined by Gakushuin University and tranquil residential streets lined with embassies. Charming bakeries and bookshops cluster around the compact station.',
+    background:
+      'https://images.unsplash.com/photo-1518860308377-0d91b5a7bb1c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [],
+    mp3Announcement: "Sites/yamanoteline/announcements/mejiro-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Mejiro.mp3"
+  },
+  {
+    id: 'takadanobaba',
+    name: 'Takadanobaba',
+    japaneseName: '高田馬場',
+    about:
+      'Takadanobaba pulses with student energy thanks to Waseda University. Retro game centers, budget eats, and jazz bars line the streets, while the Astro Boy theme plays as the station melody.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Tozai Line', code: 'T', color: '#0288d1', operator: 'Tokyo Metro' },
+      { name: 'Seibu Shinjuku Line', code: 'SS', color: '#388e3c', operator: 'Seibu Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/takadanobaba-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Takadanobaba.mp3"
+  },
+  {
+    id: 'shin-okubo',
+    name: 'Shin-Okubo',
+    japaneseName: '新大久保',
+    about:
+      'Tokyo\'s Koreatown thrives in Shin-Okubo with neon-lit restaurants, K-pop boutiques, and dessert cafés. The multicultural streets stay lively late into the evening.',
+    background:
+      'https://images.unsplash.com/photo-1503899036084-c55cdd92da26?auto=format&fit=crop&w=1600&q=80',
+    transfers: [],
+    mp3Announcement: "Sites/yamanoteline/announcements/shinokubo-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shinokubo.mp3"
+  },
+  {
+    id: 'shinjuku',
+    name: 'Shinjuku',
+    japaneseName: '新宿',
+    about:
+      'Shinjuku Station is the world\'s busiest, funneling travelers to skyscraper canyons, Kabukicho nightlife, and the calm greenery of Shinjuku Gyoen. Observation decks offer sweeping views over Tokyo.',
+    background:
+      'https://images.unsplash.com/photo-1478432780021-b8d273730d8c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo Line (Rapid)', code: 'JC', color: '#f15a24', operator: 'JR East' },
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Tokyo Metro Marunouchi Line', code: 'M', color: '#c62828', operator: 'Tokyo Metro' },
+      { name: 'Toei Oedo Line', code: 'E', color: '#7b1fa2', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shinjuku-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shinjuku.mp3"
+  },
+  {
+    id: 'yoyogi',
+    name: 'Yoyogi',
+    japaneseName: '代々木',
+    about:
+      'Yoyogi balances quiet offices with access to Yoyogi Park and the towering National Gymnasium. Art schools and climbing gyms keep the youthful spirit alive around the station.',
+    background:
+      'https://images.unsplash.com/photo-1545569341-9eb8b30979d8?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo-Sobu Line', code: 'JB', color: '#f6b27b', operator: 'JR East' },
+      { name: 'Toei Oedo Line', code: 'E', color: '#7b1fa2', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/yoyogi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Yoyogi.mp3"
+  },
+  {
+    id: 'harajuku',
+    name: 'Harajuku',
+    japaneseName: '原宿',
+    about:
+      'Harajuku is a playground for street fashion, from Takeshita Street\'s pop culture boutiques to Omotesando\'s flagship architecture. The leafy Meiji Shrine grounds offer a quiet counterpoint nearby.',
+    background:
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Chiyoda Line (Meiji-jingumae)', code: 'C', color: '#009688', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Fukutoshin Line', code: 'F', color: '#6d4c41', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/harajuku-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Harajuku.mp3"
+  },
+  {
+    id: 'shibuya',
+    name: 'Shibuya',
+    japaneseName: '渋谷',
+    about:
+      'Shibuya Crossing pulses with neon billboards, music, and constant foot traffic. The district blends next-generation retail, creative agencies, and late-night entertainment that define modern Tokyo.',
+    background:
+      'https://images.unsplash.com/photo-1518548419970-58e3b4079ab2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'JR Shonan-Shinjuku Line', code: 'JS', color: '#ef5350', operator: 'JR East' },
+      { name: 'Tokyo Metro Ginza Line', code: 'G', color: '#f9a825', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Hanzomon Line', code: 'Z', color: '#7b1fa2', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Fukutoshin Line', code: 'F', color: '#6d4c41', operator: 'Tokyo Metro' },
+      { name: 'Tokyu Den-en-toshi Line', code: 'DT', color: '#00897b', operator: 'Tokyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shibuya-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shibuya.mp3"
+  },
+  {
+    id: 'ebisu',
+    name: 'Ebisu',
+    japaneseName: '恵比寿',
+    about:
+      'Ebisu offers refined dining, craft beer bars, and the Yebisu Garden Place promenade. Brick arcades, photography museums, and relaxed terraces give the area an elegant urban village feel.',
+    background:
+      'https://images.unsplash.com/photo-1478432780021-b8d273730d8c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/ebisu-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Ebisu.mp3"
+  },
+  {
+    id: 'meguro',
+    name: 'Meguro',
+    japaneseName: '目黒',
+    about:
+      'Meguro\'s tree-lined avenues lead to specialty coffee shops, design studios, and the serene Meguro River. Spring cherry blossoms transform the riverside into a soft pink tunnel.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Namboku Line', code: 'N', color: '#26a69a', operator: 'Tokyo Metro' },
+      { name: 'Toei Mita Line', code: 'I', color: '#1565c0', operator: 'Toei' },
+      { name: 'Tokyu Meguro Line', code: 'MG', color: '#795548', operator: 'Tokyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/meguro-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Meguro.mp3"
+  },
+  {
+    id: 'gotanda',
+    name: 'Gotanda',
+    japaneseName: '五反田',
+    about:
+      'Gotanda mixes riverside offices with late-night eateries and karaoke lounges. Local izakaya clusters under the elevated tracks while megabanks loom overhead.',
+    background:
+      'https://images.unsplash.com/photo-1518548419970-58e3b4079ab2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Toei Asakusa Line', code: 'A', color: '#e53935', operator: 'Toei' },
+      { name: 'Tokyu Ikegami Line', code: 'IK', color: '#ff7043', operator: 'Tokyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/gotanda-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Gotanda.mp3"
+  },
+  {
+    id: 'osaki',
+    name: 'Osaki',
+    japaneseName: '大崎',
+    about:
+      'Redeveloped Osaki is home to tech offices, open plazas, and elevated walkways that connect Shinagawa\'s business zone. Art installations dot the corporate campuses.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Rinkai Line', code: 'R', color: '#3949ab', operator: 'Tokyo Waterfront Area Rapid Transit' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/osaki-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Osaki.mp3"
+  },
+  {
+    id: 'shinagawa',
+    name: 'Shinagawa',
+    japaneseName: '品川',
+    about:
+      'Shinagawa links Tokyo to the south with Shinkansen platforms, waterfront hotels, and the historic Tokaido road. High-rise offices and aquarium attractions make it a major gateway.',
+    background:
+      'https://images.unsplash.com/photo-1478432780021-b8d273730d8c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'JR Tokaido Line', code: 'JT', color: '#f57c00', operator: 'JR East' },
+      { name: 'Tokaido Shinkansen', code: '🚄', color: '#1b5e20', operator: 'JR Central' },
+      { name: 'Keikyu Main Line', code: 'KK', color: '#d32f2f', operator: 'Keikyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shinagawa-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shinagawa.mp3"
+  },
+  {
+    id: 'takanawa-gateway',
+    name: 'Takanawa Gateway',
+    japaneseName: '高輪ゲートウェイ',
+    about:
+      'Takanawa Gateway is the newest Yamanote station, with a light-filled design by architect Kengo Kuma. Emerging smart-city developments surround the spacious concourse.',
+    background:
+      'https://images.unsplash.com/photo-1554797589-7241bb691973?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/takanawagateway-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/TakanawaGateway.mp3"
+  },
+  {
+    id: 'tamachi',
+    name: 'Tamachi',
+    japaneseName: '田町',
+    about:
+      'Tamachi links office towers with the canalside campus of Keio University. Elevated promenades lead toward the redeveloped Shibaura waterfront and tiny yakitori bars under the tracks.',
+    background:
+      'https://images.unsplash.com/photo-1549692520-acc6669e2f0c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/tamachi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Tamachi.mp3"
+  },
+  {
+    id: 'hamamatsucho',
+    name: 'Hamamatsucho',
+    japaneseName: '浜松町',
+    about:
+      'Hamamatsucho connects to Haneda Airport via the Tokyo Monorail and sits beside the iconic Tokyo Tower. Zojoji Temple and waterfront gardens offer moments of calm in the business district.',
+    background:
+      'https://images.unsplash.com/photo-1512455102795-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'Tokyo Monorail', code: 'MO', color: '#0288d1', operator: 'Tokyo Monorail' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/hamamatsucho-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Hamamatsucho.mp3"
+  },
+  {
+    id: 'shimbashi',
+    name: 'Shimbashi',
+    japaneseName: '新橋',
+    about:
+      'Salarymen gather in Shimbashi\'s lantern-lit alleys after work, while corporate media towers rise above. The station is the historic birthplace of Japan\'s first railway terminal.',
+    background:
+      'https://images.unsplash.com/photo-1554797589-7241bb691973?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'Toei Asakusa Line', code: 'A', color: '#e53935', operator: 'Toei' },
+      { name: 'Toei Oedo Line', code: 'E', color: '#7b1fa2', operator: 'Toei' },
+      { name: 'Yurikamome Line', code: 'U', color: '#26c6da', operator: 'Yurikamome Inc.' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shimbashi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shimbashi.mp3"
+  },
+  {
+    id: 'yurakucho',
+    name: 'Yurakucho',
+    japaneseName: '有楽町',
+    about:
+      'Yurakucho combines upscale Ginza shopping with Showa-era yakitori alleys tucked under the viaducts. The Tokyo International Forum\'s glass canopy hosts design fairs and concerts year-round.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Yurakucho Line', code: 'Y', color: '#fdd835', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/yurakucho-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Yurakucho.mp3"
+  }
+];
 
-    // Layout toggle button
-    layoutToggle.addEventListener("click", () => {
-      if (document.body.classList.contains("modern-layout")) {
-        document.body.classList.remove("modern-layout");
-        layoutToggle.textContent = "Switch Layout";
-        localStorage.setItem("layout", "classic");
-        // Reposition stations for circle layout
-        placeStations();
-        generateArrows();
-        updateArrowAnimation();
-      } else {
-        document.body.classList.add("modern-layout");
-        layoutToggle.textContent = "Classic Layout";
-        localStorage.setItem("layout", "modern");
-        // Clear arrows when in modern layout
-        document.getElementById("arrowContainer").innerHTML = "";
-        // Rebuild station list without positioning
-        const stationsContainer = document.getElementById("stations");
-        stationsContainer.innerHTML = "";
-        stations.forEach((st, i) => {
-          const div = document.createElement("div");
-          div.classList.add("station");
-          div.textContent = st.name;
-          div.dataset.index = i;
-          div.addEventListener("click", () => playStation(i));
-          stationsContainer.appendChild(div);
-        });
-      }
-    });
+const viewport = document.getElementById('stationViewport');
+const backgroundEl = document.getElementById('stationBackground');
+const nameJpEl = document.getElementById('stationNameJp');
+const nameEnEl = document.getElementById('stationNameEn');
+const aboutEl = document.getElementById('stationAbout');
+const transferListEl = document.getElementById('transferLines');
+const prevPreviewEl = document.getElementById('prevStationPreview');
+const nextPreviewEl = document.getElementById('nextStationPreview');
+const playPauseBtn = document.getElementById('playPause');
+const skipBtn = document.getElementById('skipStation');
+const volumeSlider = document.getElementById('volumeSlider');
+const muteButton = document.getElementById('muteButton');
+const trackLabel = document.getElementById('currentTrackLabel');
+const rideModeButton = document.getElementById('rideModeButton');
+const ambientToggle = document.getElementById('ambientToggle');
+const mapToggle = document.getElementById('mapToggle');
+const mobileMap = document.getElementById('mobileMap');
+const mobilePlay = document.getElementById('mobilePlay');
+const mobileSkip = document.getElementById('mobileSkip');
+const mapOverlay = document.getElementById('mapOverlay');
+const closeMap = document.getElementById('closeMap');
+const loopMap = document.getElementById('loopMap');
+const searchInput = document.getElementById('stationSearch');
+const searchGoButton = document.getElementById('jumpButton');
+const datalist = document.getElementById('stationList');
 
-    // Log audio errors
-    audioElement.addEventListener("error", () => {
-      console.error("Audio error:", audioElement.error);
-    });
+const announcementAudio = document.getElementById('announcementAudio');
+const ambientAudio = document.getElementById('ambientAudio');
 
-    // Update active station button style
-    function updateActiveStation(index, mode) {
-      document.querySelectorAll(".station").forEach(el => {
-        el.classList.remove("announcement-active", "station-active");
-      });
-      const stationButton = document.querySelector(`.station[data-index="${index}"]`);
-      if (stationButton) {
-        if (mode === "announcement") {
-          stationButton.classList.add("announcement-active");
-        } else if (mode === "station") {
-          stationButton.classList.add("station-active");
-        }
-      }
+let currentStationIndex = 0;
+let scrollLock = false;
+let isMuted = false;
+let rideMode = false;
+let ambientOn = false;
+let rideTimeout = null;
+
+const volumeKey = 'yamanote-volume';
+const rideModeKey = 'yamanote-ride-mode';
+const ambientKey = 'yamanote-ambient';
+
+function clampIndex(index) {
+  const total = stations.length;
+  return (index % total + total) % total;
+}
+
+function setBackground(url) {
+  backgroundEl.classList.remove('is-active');
+  requestAnimationFrame(() => {
+    backgroundEl.style.backgroundImage = `url(${url})`;
+    requestAnimationFrame(() => backgroundEl.classList.add('is-active'));
+  });
+}
+
+function createTransferChip(transfer) {
+  const chip = document.createElement('button');
+  chip.type = 'button';
+  chip.className = 'transfer-chip';
+  chip.dataset.tooltip = `${transfer.operator}`;
+
+  const icon = document.createElement('span');
+  icon.className = 'transfer-chip__icon';
+  icon.textContent = transfer.code;
+  icon.style.background = transfer.color;
+  chip.appendChild(icon);
+
+  const label = document.createElement('span');
+  label.className = 'transfer-chip__name';
+  label.textContent = transfer.name;
+  chip.appendChild(label);
+
+  chip.addEventListener('focus', () => chip.classList.add('is-focused'));
+  chip.addEventListener('blur', () => chip.classList.remove('is-focused'));
+
+  return chip;
+}
+
+function updateTransferLines(station) {
+  transferListEl.innerHTML = '';
+  if (!station.transfers.length) {
+    const none = document.createElement('p');
+    none.className = 'transfer-lines__empty';
+    none.textContent = 'No direct transfers';
+    transferListEl.appendChild(none);
+    return;
+  }
+
+  station.transfers.forEach((transfer) => {
+    const chip = createTransferChip(transfer);
+    transferListEl.appendChild(chip);
+  });
+}
+
+function renderPreview(el, station, directionLabel, arrow) {
+  el.innerHTML = `
+    <div class="station-preview__inner">
+      <span class="station-preview__direction">${arrow} ${directionLabel}</span>
+      <span class="station-preview__jp" lang="ja">${station.japaneseName}</span>
+      <span class="station-preview__en">${station.name}</span>
+    </div>
+  `;
+}
+
+function updatePreviews(index) {
+  const prevIndex = clampIndex(index - 1);
+  const nextIndex = clampIndex(index + 1);
+  renderPreview(prevPreviewEl, stations[prevIndex], 'Previous', '▲');
+  renderPreview(nextPreviewEl, stations[nextIndex], 'Next', '▼');
+}
+
+function updateTrackLabel(mode = 'Stopped') {
+  const station = stations[currentStationIndex];
+  trackLabel.textContent = `${mode} • ${station.name}`;
+}
+
+function updatePlayButtons(isPlaying) {
+  const symbol = isPlaying ? '⏸' : '▶';
+  playPauseBtn.textContent = symbol;
+  playPauseBtn.setAttribute('aria-pressed', String(isPlaying));
+  mobilePlay.textContent = symbol;
+  mobilePlay.setAttribute('aria-pressed', String(isPlaying));
+}
+
+function stopRideTimer() {
+  if (rideTimeout) {
+    clearTimeout(rideTimeout);
+    rideTimeout = null;
+  }
+}
+
+function scheduleRideAdvance() {
+  stopRideTimer();
+  if (!rideMode) return;
+  rideTimeout = setTimeout(() => {
+    goToStation(currentStationIndex + 1, { playAudio: true });
+  }, 5000);
+}
+
+function setRideMode(enabled, options = {}) {
+  const { autoPlay = true } = options;
+  rideMode = enabled;
+  rideModeButton.setAttribute('aria-pressed', String(enabled));
+  rideModeButton.textContent = enabled ? 'Ride Mode On' : 'Ride Mode Off';
+  localStorage.setItem(rideModeKey, enabled ? '1' : '0');
+  if (enabled) {
+    if (autoPlay && announcementAudio.paused) {
+      playAnnouncement();
     }
+  } else {
+    stopRideTimer();
+  }
+}
 
-    // Update play/pause button icon
-    function updatePlayPauseIcon() {
-      playPauseBtn.textContent = audioElement.paused ? "▶" : "⏸";
-    }
-    audioElement.addEventListener("play", updatePlayPauseIcon);
-    audioElement.addEventListener("pause", updatePlayPauseIcon);
+function setAmbient(enabled) {
+  ambientOn = enabled;
+  ambientToggle.setAttribute('aria-pressed', String(enabled));
+  ambientToggle.textContent = enabled ? 'Ambient On' : 'Ambient Off';
+  localStorage.setItem(ambientKey, enabled ? '1' : '0');
+  if (enabled) {
+    applyVolume();
+    ambientAudio.play().catch(() => {});
+  } else {
+    ambientAudio.pause();
+  }
+}
 
-    // Generate inner arrow circle
-    function generateArrows() {
-      const arrowContainer = document.getElementById("arrowContainer");
-      arrowContainer.innerHTML = "";
-      const containerWidth = arrowContainer.offsetWidth;
-      const containerHeight = arrowContainer.offsetHeight;
-      const centerX = containerWidth / 2;
-      const centerY = containerHeight / 2;
-      const arrowRadius = 300;
-      const numArrows = 50;
-      for (let i = 0; i < numArrows; i++) {
-        const angle = (2 * Math.PI * i) / numArrows;
-        const x = centerX + arrowRadius * Math.cos(angle);
-        const y = centerY + arrowRadius * Math.sin(angle);
+function setMute(enabled) {
+  isMuted = enabled;
+  muteButton.setAttribute('aria-pressed', String(enabled));
+  muteButton.textContent = enabled ? 'Unmute' : 'Mute';
+  applyVolume();
+}
 
-        const arrow = document.createElement("div");
-        arrow.classList.add("arrow");
-        arrow.textContent = "➤";
-        arrow.style.left = x + "px";
-        arrow.style.top = y + "px";
-        const angleDeg = (angle * 180) / Math.PI;
-        const rotationDeg = (playDirection === 1) ? angleDeg + 90 : angleDeg - 90;
-        arrow.style.transform = `translate(-50%, -50%) rotate(${rotationDeg}deg)`;
-        arrowContainer.appendChild(arrow);
-      }
-    }
+function applyVolume() {
+  const volume = parseFloat(volumeSlider.value);
+  announcementAudio.volume = isMuted ? 0 : volume;
+  ambientAudio.volume = ambientOn ? Math.min(0.5, volume * 0.5) : 0;
+}
 
-    function updateArrowAnimation() {
-      const arrowContainer = document.getElementById("arrowContainer");
-      arrowContainer.style.animationName =
-        (playDirection === 1) ? "spinClockwise" : "spinCounterClockwise";
-      generateArrows();
-    }
+function setVolume(value) {
+  volumeSlider.value = value;
+  localStorage.setItem(volumeKey, value);
+  applyVolume();
+}
 
-    // Place stations on outer circle
-    function placeStations() {
-      const stationsContainer = document.getElementById("stations");
-      stationsContainer.innerHTML = "";
-      const containerWidth = stationsContainer.offsetWidth;
-      const containerHeight = stationsContainer.offsetHeight;
-      const centerX = containerWidth / 2;
-      const centerY = containerHeight / 2;
-      const stationRadius = 380;
-      const totalStations = stations.length;
+function goToStation(index, options = {}) {
+  const { playAudio = false } = options;
+  currentStationIndex = clampIndex(index);
+  stopRideTimer();
+  const station = stations[currentStationIndex];
 
-      for (let i = 0; i < totalStations; i++) {
-        const angle = (2 * Math.PI * i) / totalStations - Math.PI / 2;
-        const x = centerX + stationRadius * Math.cos(angle);
-        const y = centerY + stationRadius * Math.sin(angle);
+  setBackground(station.background);
+  nameJpEl.textContent = station.japaneseName;
+  nameEnEl.textContent = station.name;
+  aboutEl.textContent = station.about;
+  updateTransferLines(station);
+  updatePreviews(currentStationIndex);
+  updateTrackLabel('Ready');
+  rotateMapToIndex(currentStationIndex);
 
-        const stationDiv = document.createElement("div");
-        stationDiv.classList.add("station");
-        stationDiv.textContent = stations[i].name;
-        stationDiv.style.left = x + "px";
-        stationDiv.style.top = y + "px";
-        stationDiv.dataset.index = i;
-        stationDiv.addEventListener("click", () => {
-          playStation(i);
-        });
-        stationsContainer.appendChild(stationDiv);
-      }
-    }
+  announcementAudio.src = getAnnouncementSrc(station);
 
-    // Playback logic
-    function playStation(index) {
-      currentStationIndex = index;
-      const station = stations[index];
-      audioElement.onended = null;
-      updateActiveStation(index, "");
+  if (playAudio) {
+    playAnnouncement();
+  } else {
+    updatePlayButtons(false);
+    announcementAudio.pause();
+  }
+}
 
-      // If skip announcements is OFF, play announcement first
-      if (!skipAnnouncementToggle.checked) {
-        currentAudioType = "announcement";
-        currentStationLabel.textContent = station.name + " (announcement)";
-        audioElement.src = station.mp3Announcement + cacheBust;
-        audioElement.volume = announcementMuted ? 0 : announcementVolume;
-        audioElement.play().then(() => {
-          updateActiveStation(index, "announcement");
-          audioElement.onended = () => {
-            playStationAudio(station);
-          };
-        }).catch(err => {
-          console.error("Announcement playback failed:", err);
-          playStationAudio(station);
-        });
-      } else {
-        // Skip announcements
-        playStationAudio(station);
-      }
-    }
+function playAnnouncement() {
+  const station = stations[currentStationIndex];
+  announcementAudio.src = getAnnouncementSrc(station);
+  applyVolume();
+  announcementAudio
+    .play()
+    .then(() => {
+      updatePlayButtons(true);
+      updateTrackLabel('Announcement');
+    })
+    .catch((error) => {
+      console.error('Unable to play audio', error);
+      updatePlayButtons(false);
+      updateTrackLabel('Audio unavailable');
+    });
+}
 
-    function playStationAudio(station) {
-      currentAudioType = "station";
-      currentStationLabel.textContent = station.name;
-      audioElement.src = station.mp3Station + cacheBust;
-      audioElement.volume = stationMuted ? 0 : stationVolume;
-      audioElement.play().then(() => {
-        updateActiveStation(currentStationIndex, "station");
-        audioElement.onended = () => {
-          nextStation();
-        };
-      }).catch(err => {
-        console.error("Station playback failed:", err);
-      });
-    }
+function togglePlayPause() {
+  if (announcementAudio.paused) {
+    playAnnouncement();
+  } else {
+    announcementAudio.pause();
+  }
+}
 
-    function nextStation() {
-      let nextIndex = currentStationIndex + playDirection;
-      if (nextIndex >= stations.length) nextIndex = 0;
-      if (nextIndex < 0) nextIndex = stations.length - 1;
-      playStation(nextIndex);
-    }
+function handleAudioEnd() {
+  updatePlayButtons(false);
+  updateTrackLabel('Finished');
+  if (rideMode) {
+    scheduleRideAdvance();
+  }
+}
 
-    // Play/pause button
-    playPauseBtn.addEventListener("click", () => {
-      if (audioElement.paused) {
-        audioElement.play();
-      } else {
-        audioElement.pause();
-      }
+function handleAudioPlay() {
+  updatePlayButtons(true);
+  updateTrackLabel('Announcement');
+}
+
+function handleAudioPause() {
+  updatePlayButtons(false);
+  if (!announcementAudio.ended) {
+    updateTrackLabel('Paused');
+  }
+}
+
+function openMap() {
+  mapOverlay.classList.add('is-visible');
+  mapOverlay.setAttribute('aria-hidden', 'false');
+  mapToggle.setAttribute('aria-expanded', 'true');
+  mobileMap.setAttribute('aria-expanded', 'true');
+}
+
+function closeMapOverlay() {
+  mapOverlay.classList.remove('is-visible');
+  mapOverlay.setAttribute('aria-hidden', 'true');
+  mapToggle.setAttribute('aria-expanded', 'false');
+  mobileMap.setAttribute('aria-expanded', 'false');
+}
+
+function buildMap() {
+  loopMap.innerHTML = '';
+  const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  group.classList.add('loop-group');
+  loopMap.appendChild(group);
+
+  const view = loopMap.viewBox.baseVal;
+  const width = view?.width ?? 1400;
+  const height = view?.height ?? 400;
+  const padding = 140;
+  const centerY = height / 2;
+  const spacing = stations.length > 1 ? (width - padding * 2) / (stations.length - 1) : 0;
+
+  const track = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  track.classList.add('loop-track');
+  track.setAttribute('x1', padding);
+  track.setAttribute('y1', centerY);
+  track.setAttribute('x2', width - padding);
+  track.setAttribute('y2', centerY);
+  group.appendChild(track);
+
+  const progress = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  progress.classList.add('loop-progress');
+  progress.setAttribute('id', 'loopProgress');
+  progress.setAttribute('x1', padding);
+  progress.setAttribute('y1', centerY);
+  progress.setAttribute('x2', padding);
+  progress.setAttribute('y2', centerY);
+  group.appendChild(progress);
+
+  stations.forEach((station, index) => {
+    const x = padding + spacing * index;
+    const node = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    node.classList.add('loop-node');
+    node.dataset.index = String(index);
+    node.dataset.x = x.toFixed(2);
+    node.setAttribute('transform', `translate(${x.toFixed(2)}, ${centerY.toFixed(2)})`);
+
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', '0');
+    circle.setAttribute('cy', '0');
+    circle.setAttribute('r', '12');
+    node.appendChild(circle);
+
+    const textOffset = index % 2 === 0 ? 38 : -32;
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('x', '0');
+    text.setAttribute('y', textOffset.toFixed(2));
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('dominant-baseline', textOffset < 0 ? 'ideographic' : 'hanging');
+    text.textContent = station.name;
+    node.appendChild(text);
+
+    node.addEventListener('click', () => {
+      rotateMapToIndex(index);
+      setTimeout(() => {
+        goToStation(index, { playAudio: false });
+        closeMapOverlay();
+      }, 300);
     });
 
-    // Volume sliders
-    document.getElementById("announcementVolumeSlider").addEventListener("input", e => {
-      announcementVolume = parseFloat(e.target.value);
-      if (currentAudioType === "announcement" && !announcementMuted) {
-        audioElement.volume = announcementVolume;
-      }
-    });
-    document.getElementById("stationVolumeSlider").addEventListener("input", e => {
-      stationVolume = parseFloat(e.target.value);
-      if (currentAudioType === "station" && !stationMuted) {
-        audioElement.volume = stationVolume;
-      }
-    });
+    group.appendChild(node);
+  });
 
-    // Mute toggles
-    document.getElementById("announcementVolumeIcon").addEventListener("click", () => {
-      announcementMuted = !announcementMuted;
-      const icon = document.getElementById("announcementVolumeIcon");
-      icon.textContent = announcementMuted ? "🔇" : "🔊";
-      if (currentAudioType === "announcement") {
-        audioElement.volume = announcementMuted ? 0 : announcementVolume;
-      }
-    });
-    document.getElementById("stationVolumeIcon").addEventListener("click", () => {
-      stationMuted = !stationMuted;
-      const icon = document.getElementById("stationVolumeIcon");
-      icon.textContent = stationMuted ? "🔇" : "🔊";
-      if (currentAudioType === "station") {
-        audioElement.volume = stationMuted ? 0 : stationVolume;
-      }
-    });
+  highlightMapNode(currentStationIndex);
+}
 
-    // Direction toggle
-    directionToggle.addEventListener("change", () => {
-      if (directionToggle.checked) {
-        playDirection = 1;
-        directionText.textContent = "Clockwise";
-      } else {
-        playDirection = -1;
-        directionText.textContent = "Counterclockwise";
-      }
-      updateArrowAnimation();
-    });
+function rotateMapToIndex(index) {
+  highlightMapNode(index);
+}
 
-    // On window load
-    window.onload = function() {
-      const savedLayout = localStorage.getItem("layout");
-      if (savedLayout === "modern") {
-        document.body.classList.add("modern-layout");
-        layoutToggle.textContent = "Classic Layout";
-        // Build grid layout
-        document.getElementById("arrowContainer").innerHTML = "";
-        const stationsContainer = document.getElementById("stations");
-        stations.forEach((st, i) => {
-          const div = document.createElement("div");
-          div.classList.add("station");
-          div.textContent = st.name;
-          div.dataset.index = i;
-          div.addEventListener("click", () => playStation(i));
-          stationsContainer.appendChild(div);
-        });
-      } else {
-        layoutToggle.textContent = "Switch Layout";
-        generateArrows();
-        updateArrowAnimation();
-        placeStations();
+function highlightMapNode(index = currentStationIndex) {
+  const nodes = loopMap.querySelectorAll('.loop-node');
+  nodes.forEach((node) => node.classList.remove('active'));
+  const active = loopMap.querySelector(`.loop-node[data-index="${index}"]`);
+  if (active) {
+    active.classList.add('active');
+    const progress = loopMap.querySelector('#loopProgress');
+    if (progress) {
+      const x = parseFloat(active.dataset.x || progress.getAttribute('x1') || '0');
+      progress.setAttribute('x2', x.toFixed(2));
+    }
+  }
+}
+
+function navigate(delta) {
+  if (scrollLock) return;
+  scrollLock = true;
+  goToStation(currentStationIndex + delta, { playAudio: rideMode });
+  setTimeout(() => {
+    scrollLock = false;
+  }, 650);
+}
+
+function handleWheel(event) {
+  if (mapOverlay.classList.contains('is-visible')) return;
+  if (Math.abs(event.deltaY) < 30) return;
+  navigate(event.deltaY > 0 ? 1 : -1);
+}
+
+let touchStartY = null;
+
+function handleTouchStart(event) {
+  touchStartY = event.touches[0]?.clientY ?? null;
+}
+
+function handleTouchEnd(event) {
+  if (touchStartY === null) return;
+  const endY = event.changedTouches[0]?.clientY ?? touchStartY;
+  const diff = touchStartY - endY;
+  if (Math.abs(diff) > 40) {
+    navigate(diff > 0 ? 1 : -1);
+  }
+  touchStartY = null;
+}
+
+function handleKeydown(event) {
+  if (mapOverlay.classList.contains('is-visible')) return;
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      navigate(1);
+      break;
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      navigate(-1);
+      break;
+    case ' ': // space
+      event.preventDefault();
+      togglePlayPause();
+      break;
+    case 'Enter':
+      if (document.activeElement === searchInput) {
+        jumpToSearch();
       }
-    };
+      break;
+    default:
+      break;
+  }
+}
+
+function jumpToSearch() {
+  const query = searchInput.value.trim();
+  if (!query) return;
+  const normalized = query.toLowerCase();
+  const foundIndex = stations.findIndex((station) => {
+    return (
+      station.name.toLowerCase() === normalized ||
+      station.japaneseName === query ||
+      station.name.toLowerCase().includes(normalized) ||
+      station.japaneseName.includes(query)
+    );
+  });
+  if (foundIndex >= 0) {
+    goToStation(foundIndex, { playAudio: rideMode });
+    closeMapOverlay();
+  }
+}
+
+function populateSearchOptions() {
+  datalist.innerHTML = '';
+  stations.forEach((station) => {
+    const optionEn = document.createElement('option');
+    optionEn.value = station.name;
+    datalist.appendChild(optionEn);
+
+    const optionJp = document.createElement('option');
+    optionJp.value = station.japaneseName;
+    datalist.appendChild(optionJp);
+  });
+}
+
+function hydrateSettings() {
+  const storedVolume = localStorage.getItem(volumeKey);
+  setVolume(storedVolume ?? '0.8');
+
+  const storedRideValue = localStorage.getItem(rideModeKey);
+  const shouldRide = storedRideValue === null ? true : storedRideValue === '1';
+  setRideMode(shouldRide, { autoPlay: false });
+
+  const storedAmbient = localStorage.getItem(ambientKey) === '1';
+  setAmbient(storedAmbient);
+}
+
+function bindEvents() {
+  playPauseBtn.addEventListener('click', togglePlayPause);
+  skipBtn.addEventListener('click', () => navigate(1));
+  mobilePlay.addEventListener('click', togglePlayPause);
+  mobileSkip.addEventListener('click', () => navigate(1));
+  volumeSlider.addEventListener('input', (event) => setVolume(event.target.value));
+  muteButton.addEventListener('click', () => setMute(!isMuted));
+  rideModeButton.addEventListener('click', () => setRideMode(!rideMode));
+  ambientToggle.addEventListener('click', () => setAmbient(!ambientOn));
+  mapToggle.addEventListener('click', () => {
+    if (mapOverlay.classList.contains('is-visible')) {
+      closeMapOverlay();
+    } else {
+      openMap();
+    }
+  });
+  mobileMap.addEventListener('click', () => {
+    if (mapOverlay.classList.contains('is-visible')) {
+      closeMapOverlay();
+    } else {
+      openMap();
+    }
+  });
+  closeMap.addEventListener('click', closeMapOverlay);
+  mapOverlay.addEventListener('click', (event) => {
+    if (event.target === mapOverlay) {
+      closeMapOverlay();
+    }
+  });
+  viewport.addEventListener('wheel', handleWheel, { passive: true });
+  viewport.addEventListener('touchstart', handleTouchStart, { passive: true });
+  viewport.addEventListener('touchend', handleTouchEnd, { passive: true });
+  document.addEventListener('keydown', handleKeydown);
+  announcementAudio.addEventListener('ended', handleAudioEnd);
+  announcementAudio.addEventListener('pause', handleAudioPause);
+  announcementAudio.addEventListener('play', handleAudioPlay);
+  searchInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      jumpToSearch();
+    }
+  });
+  searchGoButton.addEventListener('click', jumpToSearch);
+}
+
+function init() {
+  populateSearchOptions();
+  buildMap();
+  hydrateSettings();
+  goToStation(0, { playAudio: rideMode });
+  rotateMapToIndex(0);
+  bindEvents();
+}
+
+init();

--- a/Sites/yamanoteline/style.css
+++ b/Sites/yamanoteline/style.css
@@ -1,257 +1,632 @@
-/* Basic reset */
-html, body {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  font-family: Arial, sans-serif;
-  background-color: #fff;
+:root {
+  color-scheme: dark;
+  --bg-dark: rgba(5, 15, 30, 0.75);
+  --glass: rgba(15, 25, 45, 0.75);
+  --accent: #3fc3ff;
+  --accent-strong: #1f91ff;
+  --text-primary: #f4f7fa;
+  --text-muted: rgba(244, 247, 250, 0.7);
+  --info-bg: rgba(20, 35, 60, 0.65);
+  --shadow-lg: 0 25px 60px rgba(0, 0, 0, 0.45);
+  --transition-fast: 200ms ease;
 }
 
-/* Dark mode styles */
-body.dark-mode {
-  background-color: #222;
-  color: #eee;
-}
-body.dark-mode .station {
-  border-color: #888;
-  background-color: #333;
-  color: #eee;
-}
-body.dark-mode .station:hover {
-  background-color: #444;
-}
-body.dark-mode .arrow {
-  color: #aaa;
-}
-body.dark-mode #audioPlayer {
-  background-color: #333;
-  box-shadow: 0 -2px 10px rgba(255,255,255,0.1);
-}
-body.dark-mode .volume-label,
-body.dark-mode .switch-control,
-body.dark-mode #skipText,
-body.dark-mode #directionText,
-body.dark-mode #darkModeText {
-  color: #ccc;
-}
-body.dark-mode .control-button {
-  color: #ccc;
-}
-body.dark-mode .control-button:hover {
-  color: #fff;
-}
-
-/* Circle wrapper for arrows and stations */
-#circleWrapper {
-  width: 700px;
-  height: 700px;
-  margin: 40px auto 0;
-  position: relative;
+* {
   box-sizing: border-box;
-  /* Remove background color to avoid gray box */
-  background-color: transparent;
 }
 
-/* Arrow container behind stations */
-#arrowContainer {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Poppins', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--text-primary);
+  background: #020812;
   overflow: hidden;
-  animation-duration: 60s;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-  z-index: 1;
 }
 
-@keyframes spinClockwise {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
-}
-@keyframes spinCounterClockwise {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(-360deg); }
+img {
+  max-width: 100%;
+  display: block;
 }
 
-/* Arrow styling */
-.arrow {
-  position: absolute;
-  font-size: 1em;
-  color: #91c73e;
-  opacity: 0.7;
-}
-
-/* Stations container (same size as #circleWrapper) */
-#stations {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
-  z-index: 2;
-}
-
-/* Station items placed on outer circle */
-.station {
-  position: absolute;
-  padding: 5px 10px;
-  border: 2px solid #91c73e;
-  border-radius: 8px;
-  background-color: #f9f9f9;
+button {
+  font: inherit;
+  color: inherit;
   cursor: pointer;
-  font-size: 0.85em;
-  white-space: nowrap;
-  transform: translate(-50%, -50%);
-  transition: background-color 0.2s ease;
-  overflow: visible;
-}
-.station:hover {
-  background-color: #e0f0c0;
-}
-@keyframes pulse {
-  0%   { background-color: #A3D977; }
-  50%  { background-color: #7B9036; }
-  100% { background-color: #A3D977; }
-}
-.station.announcement-active {
-  animation: pulse 1.5s infinite;
-}
-.station.station-active {
-  background-color: #7B9036;
+  border: none;
+  background: none;
 }
 
-/* Audio bar pinned at bottom (100px tall) */
-#audioPlayer {
+button:focus-visible,
+input:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.app {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
   position: fixed;
-  bottom: 0;
+  top: 0;
   left: 0;
   right: 0;
-  height: 100px;
-  background-color: #fff;
-  box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: 5px 20px;
-  box-sizing: border-box;
-  z-index: 10;
+  padding: 1rem 2rem;
+  z-index: 20;
+  backdrop-filter: blur(14px);
+  background: linear-gradient(180deg, rgba(2, 8, 18, 0.85) 0%, rgba(2, 8, 18, 0.35) 100%);
+  gap: 1rem;
 }
 
-/* Left controls: volume sliders horizontally */
-.left-controls {
+.search-wrapper {
   display: flex;
-  flex-direction: row;
-  gap: 10px;
   align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
+
+.search-wrapper input[type="search"] {
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.95rem;
+  width: min(240px, 30vw);
+}
+
+.search-wrapper input::placeholder {
+  color: var(--text-muted);
+}
+
+.ghost-button {
+  padding: 0.4rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.ghost-button:hover,
+.ghost-button[aria-pressed="true"],
+.ghost-button[aria-expanded="true"] {
+  background: rgba(63, 195, 255, 0.25);
+}
+
+.ghost-button:active {
+  transform: scale(0.97);
+}
+
+.top-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.station-viewport {
+  position: relative;
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: 4rem 3rem;
+  overflow: hidden;
+}
+
+.station-background {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: saturate(0.6) brightness(0.6) blur(0px);
+  transition: opacity 600ms ease, transform 600ms ease;
+  opacity: 0;
+  transform: scale(1.05);
+}
+
+.station-background::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.65));
+}
+
+.station-background.is-active {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.station-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(2, 8, 18, 0.25) 20%, rgba(2, 8, 18, 0.85) 85%);
+  pointer-events: none;
+}
+
+.station-preview {
+  position: absolute;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 4;
+}
+
+.station-preview--previous {
+  top: 1.5rem;
+}
+
+.station-preview--next {
+  bottom: 2rem;
+}
+
+.station-preview__inner {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  background: rgba(6, 18, 36, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.station-preview__direction {
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.station-preview__jp {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+}
+
+.station-preview__en {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.station-content {
+  position: relative;
+  z-index: 5;
+  max-width: min(680px, 90vw);
+  text-align: center;
+  display: grid;
+  gap: 1.8rem;
+}
+
+.station-name__jp {
+  font-family: 'Noto Sans JP', 'Poppins', sans-serif;
+  font-size: clamp(3.5rem, 6vw, 5.5rem);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  display: block;
+}
+
+.station-name__en {
+  display: block;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.station-info {
+  background: var(--info-bg);
+  padding: 1.5rem 2rem;
+  border-radius: 1.25rem;
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(18px);
+}
+
+.station-info__heading {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.station-info p {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+.transfer-lines {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.transfer-lines__heading {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.transfer-lines__list {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.transfer-lines__empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.transfer-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  transition: transform var(--transition-fast), background var(--transition-fast);
+}
+
+.transfer-chip__icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #111;
+  background: #fff;
+}
+
+.transfer-chip__name {
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+
+.transfer-chip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(4, 10, 20, 0.85);
+  color: #fff;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.6rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+}
+
+.transfer-chip:hover::after,
+.transfer-chip:focus-visible::after {
+  opacity: 1;
+}
+
+.audio-panel {
+  position: absolute;
+  right: clamp(1rem, 5vw, 3rem);
+  bottom: clamp(2rem, 6vw, 4rem);
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.4rem;
+  border-radius: 1.25rem;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-lg);
+  z-index: 10;
+  width: min(360px, 90vw);
+}
+
+.audio-panel__primary,
+.audio-panel__secondary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.control-button {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #021021;
+  font-size: 1.2rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(31, 145, 255, 0.35);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.control-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(31, 145, 255, 0.45);
+}
+
 .volume-control {
   display: flex;
   align-items: center;
-  gap: 4px;
-}
-.volume-label {
-  font-size: 0.85em;
-  color: #555;
-}
-.volume-icon {
-  font-size: 1.1em;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #91c73e;
-}
-.volume-icon:hover {
-  color: #7B9036;
-}
-#announcementVolumeSlider,
-#stationVolumeSlider {
-  width: 90px;
+  gap: 0.65rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: rgba(255, 255, 255, 0.65);
 }
 
-/* Center controls: station name + play/pause button (stacked) */
-.center-controls {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-#currentStation {
-  font-weight: bold;
-  font-size: 1.1em;
-  margin-bottom: 4px;
-}
-.control-button {
-  background: none;
-  border: none;
-  font-size: 2em;
-  cursor: pointer;
-  color: #91c73e;
-  padding: 5px;
-}
-.control-button:hover {
-  color: #7B9036;
+.volume-control input[type="range"] {
+  width: 160px;
+  accent-color: var(--accent);
 }
 
-/* Right controls: toggles horizontally */
-.right-controls {
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  align-items: center;
-}
-.switch-control {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.85em;
-  color: #555;
-}
-#skipText, #directionText, #darkModeText {
-  min-width: 80px;
-  text-align: right;
+.track-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
-/* Toggle switch styling */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 22px;
+.mobile-dock {
+  position: fixed;
+  bottom: 1.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.65);
+  border-radius: 999px;
+  display: none;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-lg);
+  z-index: 25;
 }
-.switch input {
+
+.dock-button {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-primary);
+  font-size: 1.3rem;
+  font-weight: 600;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.dock-button:hover,
+.dock-button:focus-visible,
+.dock-button[aria-pressed="true"],
+.dock-button[aria-expanded="true"] {
+  background: rgba(63, 195, 255, 0.35);
+}
+
+.map-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(2, 8, 18, 0.85);
+  backdrop-filter: blur(14px);
   opacity: 0;
-  width: 0;
-  height: 0;
+  pointer-events: none;
+  transition: opacity 300ms ease;
+  z-index: 30;
 }
-.slider {
+
+.map-overlay.is-visible {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.map-overlay__inner {
+  width: min(960px, 95vw);
+  aspect-ratio: 16 / 9;
+  background: rgba(2, 10, 22, 0.9);
+  border-radius: 2.5rem;
+  padding: 2rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 1rem;
+}
+
+.map-overlay__inner h2 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.map-overlay__close {
   position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  font-size: 1.5rem;
+}
+
+#loopMap {
+  width: 100%;
+  height: 100%;
+}
+
+#loopMap .loop-group {
+  transition: transform 400ms ease;
+}
+
+.loop-track {
+  stroke: rgba(255, 255, 255, 0.18);
+  stroke-width: 14;
+  stroke-linecap: round;
+}
+
+.loop-progress {
+  stroke: var(--accent);
+  stroke-width: 14;
+  stroke-linecap: round;
+  transition: x2 400ms ease;
+}
+
+.loop-node {
   cursor: pointer;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background-color: #ccc;
-  transition: 0.4s;
-  border-radius: 22px;
+  transition: transform var(--transition-fast), fill var(--transition-fast);
 }
-.slider:before {
+
+.loop-node circle {
+  fill: rgba(255, 255, 255, 0.75);
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.loop-node text {
+  fill: rgba(255, 255, 255, 0.72);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+}
+
+.loop-node:hover circle {
+  fill: var(--accent);
+}
+
+.loop-node.active circle {
+  fill: var(--accent-strong);
+  box-shadow: 0 0 35px rgba(0, 232, 255, 0.55);
+  animation: mapPulse 2.4s ease-in-out infinite;
+}
+
+.loop-node.active text {
+  fill: rgba(255, 255, 255, 0.95);
+}
+
+@keyframes mapPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 18px rgba(0, 232, 255, 0.35);
+  }
+  50% {
+    transform: scale(1.35);
+    box-shadow: 0 0 38px rgba(0, 232, 255, 0.65);
+  }
+}
+
+.sr-only {
   position: absolute;
-  content: "";
-  height: 16px;
-  width: 16px;
-  left: 3px;
-  bottom: 3px;
-  background-color: #fff;
-  transition: 0.4s;
-  border-radius: 50%;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
-input:checked + .slider {
-  background-color: #91c73e;
+
+@media (max-width: 1024px) {
+  .top-bar {
+    padding: 0.75rem 1.25rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+
+  .search-wrapper input[type="search"] {
+    width: min(220px, 50vw);
+  }
+
+  .audio-panel {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: 7rem;
+  }
 }
-input:focus + .slider {
-  box-shadow: 0 0 1px #91c73e;
+
+@media (max-width: 768px) {
+  body {
+    overflow: hidden;
+  }
+
+  .station-viewport {
+    padding: 5rem 1.5rem 7rem;
+  }
+
+  .station-preview {
+    font-size: 0.85rem;
+  }
+
+  .station-preview__inner {
+    padding: 0.6rem 1rem;
+    gap: 0.05rem;
+  }
+
+  .station-preview__jp {
+    font-size: 1rem;
+  }
+
+  .station-preview__en {
+    font-size: 0.65rem;
+  }
+
+  .station-info {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .transfer-lines__list {
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  .transfer-chip {
+    padding: 0.55rem 0.85rem;
+  }
+
+  .transfer-chip__icon {
+    width: 30px;
+    height: 30px;
+  }
+
+  .audio-panel {
+    display: none;
+  }
+
+  .mobile-dock {
+    display: flex;
+  }
 }
-input:checked + .slider:before {
-  transform: translateX(18px);
-}
-.slider.round {
-  border-radius: 22px;
-}
-.slider.round:before {
-  border-radius: 50%;
+
+@media (max-width: 520px) {
+  .top-bar {
+    flex-direction: column;
+  }
+
+  .station-name__jp {
+    font-size: clamp(2.8rem, 10vw, 4rem);
+  }
+
+  .station-name__en {
+    letter-spacing: 0.18em;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the Yamanote station page into a full-screen carousel with immersive backgrounds, contextual info, transfers, audio controls, search, and map overlay
- restyle the experience with glassmorphism panels, mobile dock controls, animated previews, and responsive layouts
- refactor station logic with a rich 30-station dataset, ride mode autoplay, ambient audio, swipe/scroll navigation, and an interactive SVG loop map
- ensure announcement audio uses the bundled local files so playback works reliably under the tightened CSP
- default ride mode autoplay, convert the map overlay into a linear timeline, and surface clearer previous/next station previews per review feedback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a1c934948328999813d659c73af4