### PR TITLE
Rebuild Yamanote site with immersive carousel design

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -3,66 +3,86 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Yamanote Line - Stations on Circle with Dark Mode</title>
-  <!-- Basic Content Security Policy -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
+  <title>Yamanote Line Immersive Guide</title>
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; img-src 'self' data: https://images.unsplash.com https://media.timeout.com https://upload.wikimedia.org https://cdn.pixabay.com; media-src 'self' https://madewithonlyai.com https://cdn.pixabay.com; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; script-src 'self'; connect-src 'self';">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="layout-modern.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <!-- Circle wrapper for arrows and station labels -->
-  <div id="circleWrapper">
-    <div id="arrowContainer"></div>
-    <div id="stations"></div>
+  <div id="app" class="app">
+    <header class="top-bar">
+      <button id="mapToggle" class="ghost-button" aria-expanded="false">Map</button>
+      <div class="search-wrapper">
+        <label class="sr-only" for="stationSearch">Search stations</label>
+        <input id="stationSearch" list="stationList" type="search" placeholder="Search stations…" autocomplete="off">
+        <datalist id="stationList"></datalist>
+        <button id="jumpButton" class="ghost-button">Go</button>
+      </div>
+      <div class="top-actions">
+        <button id="rideModeButton" class="ghost-button" aria-pressed="true">Ride Mode On</button>
+        <button id="ambientToggle" class="ghost-button" aria-pressed="false">Ambient Off</button>
+      </div>
+    </header>
+
+    <main id="stationViewport" class="station-viewport" tabindex="0">
+      <div id="stationBackground" class="station-background" role="img" aria-live="polite"></div>
+      <div class="station-backdrop"></div>
+
+      <div id="prevStationPreview" class="station-preview station-preview--previous" aria-hidden="true"></div>
+      <div id="nextStationPreview" class="station-preview station-preview--next" aria-hidden="true"></div>
+
+      <section class="station-content">
+        <div class="station-titles">
+          <h1 id="stationNameJp" class="station-title station-title--jp" lang="ja"></h1>
+          <p id="stationNameEn" class="station-title station-title--en"></p>
+        </div>
+        <article class="station-info" aria-live="polite">
+          <h2 class="station-info__heading">About</h2>
+          <p id="stationAbout" class="station-info__body"></p>
+        </article>
+        <section class="transfer-lines" aria-label="Transfer lines">
+          <h3 class="transfer-lines__heading">Transfers</h3>
+          <div id="transferLines" class="transfer-lines__list"></div>
+        </section>
+      </section>
+
+      <div class="audio-panel" role="region" aria-label="Station announcements">
+        <div class="audio-panel__controls">
+          <button id="playPause" class="control-button" aria-pressed="false">▶</button>
+          <button id="skipStation" class="control-button" aria-label="Skip to next station">⏭</button>
+        </div>
+        <div class="audio-panel__meta">
+          <span id="currentTrackLabel" class="track-label"></span>
+          <label class="volume-control" for="volumeSlider">
+            <span class="sr-only">Announcement volume</span>
+            <input id="volumeSlider" type="range" min="0" max="1" step="0.01">
+          </label>
+          <button id="muteButton" class="ghost-button" aria-pressed="false">Mute</button>
+        </div>
+      </div>
+    </main>
+
+    <nav class="mobile-dock" aria-label="Mobile controls">
+      <button id="mobilePlay" class="dock-button" aria-pressed="false">▶</button>
+      <button id="mobileSkip" class="dock-button" aria-label="Skip to next">⏭</button>
+      <button id="mobileMap" class="dock-button" aria-expanded="false">Map</button>
+    </nav>
+
+    <aside id="mapOverlay" class="map-overlay" aria-hidden="true">
+      <div class="map-overlay__inner">
+        <button id="closeMap" class="ghost-button map-overlay__close" aria-label="Close map">×</button>
+        <h2 class="map-overlay__title">Yamanote Loop</h2>
+        <svg id="loopMap" viewBox="0 0 600 600" role="img" aria-label="Interactive map of the Yamanote Line"></svg>
+      </div>
+    </aside>
   </div>
 
-  <!-- Audio bar at the bottom (single horizontal row) -->
-  <div id="audioPlayer">
-    <div class="left-controls">
-      <div class="volume-control">
-        <span class="volume-label">Announcement</span>
-        <button class="volume-icon" id="announcementVolumeIcon">🔊</button>
-        <input type="range" id="announcementVolumeSlider" min="0" max="1" step="0.01" value="1">
-      </div>
-      <div class="volume-control">
-        <span class="volume-label">Station</span>
-        <button class="volume-icon" id="stationVolumeIcon">🔊</button>
-        <input type="range" id="stationVolumeSlider" min="0" max="1" step="0.01" value="1">
-      </div>
-    </div>
-    <div class="center-controls">
-      <span id="currentStation">No station selected</span>
-      <button id="playPauseBtn" class="control-button">▶</button>
-    </div>
-    <div class="right-controls">
-      <div class="switch-control">
-        <span id="skipText">Skip Announcements</span>
-        <label class="switch">
-          <input type="checkbox" id="skipAnnouncement">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="switch-control">
-        <span id="directionText">Clockwise</span>
-        <label class="switch">
-          <input type="checkbox" id="directionToggle" checked>
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <div class="switch-control">
-        <span id="darkModeText">Light Mode</span>
-        <label class="switch">
-          <input type="checkbox" id="darkModeToggle">
-          <span class="slider round"></span>
-        </label>
-      </div>
-      <button id="layoutToggle" class="layout-button">Switch Layout</button>
-    </div>
-  </div>
+  <audio id="announcementAudio" preload="auto" crossorigin="anonymous"></audio>
+  <audio id="ambientAudio" preload="auto" loop crossorigin="anonymous" src="https://cdn.pixabay.com/audio/2022/03/15/audio_54c178aeb5.mp3"></audio>
 
-  <!-- Hidden audio element for playback -->
-  <audio id="audio" preload="auto"></audio>
-
-  <script src="main.js"></script>
+  <script src="main.js" type="module"></script>
 </body>
 </html>

--- a/Sites/yamanoteline/main.js
+++ b/Sites/yamanoteline/main.js
@@ -1,311 +1,1024 @@
-    // Cache busting query param
-    const cacheBust = "?v=1";
+const CACHE_BUST = '?v=202403';
 
-    // All 30 Yamanote stations
-    const stations = [
-      { name: "Tokyo",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tokyo-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tokyo.mp3" },
-      { name: "Kanda",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/kanda-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Kanda.mp3" },
-      { name: "Akihabara",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/akihabara-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Akihabara.mp3" },
-      { name: "Okachimachi",    mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/okachimachi-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Okachimachi.mp3" },
-      { name: "Ueno",           mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/ueno-announcement.mp3",        mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Ueno.mp3" },
-      { name: "Uguisudani",     mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/uguisudani-announcement.mp3",  mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Uguisudani.mp3" },
-      { name: "Nippori",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/nippori-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Nippori.mp3" },
-      { name: "Nishi-Nippori",  mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/nishinippori-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Nishinippori.mp3" },
-      { name: "Tabata",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tabata-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tabata.mp3" },
-      { name: "Komagome",       mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/komagome-announcement.mp3",    mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Komagome.mp3" },
-      { name: "Sugamo",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/sugamo-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Sugamo.mp3" },
-      { name: "Otsuka",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/otsuka-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Otsuka.mp3" },
-      { name: "Ikebukuro",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/ikebukuro-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Ikebukuro.mp3" },
-      { name: "Mejiro",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/mejiro-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Mejiro.mp3" },
-      { name: "Takadanobaba",   mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/takadanobaba-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Takadanobaba.mp3" },
-      { name: "Shin-Okubo",     mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shinokubo-announcement.mp3",  mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shinokubo.mp3" },
-      { name: "Shinjuku",       mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shinjuku-announcement.mp3",    mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shinjuku.mp3" },
-      { name: "Yoyogi",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/yoyogi-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Yoyogi.mp3" },
-      { name: "Harajuku",       mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/harajuku-announcement.mp3",    mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Harajuku.mp3" },
-      { name: "Shibuya",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shibuya-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shibuya.mp3" },
-      { name: "Ebisu",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/ebisu-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Ebisu.mp3" },
-      { name: "Meguro",         mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/meguro-announcement.mp3",      mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Meguro.mp3" },
-      { name: "Gotanda",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/gotanda-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Gotanda.mp3" },
-      { name: "Osaki",          mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/osaki-announcement.mp3",       mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Osaki.mp3" },
-      { name: "Shinagawa",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shinagawa-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shinagawa.mp3" },
-      { name: "Takanawa Gateway", mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/takanawagateway-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/TakanawaGateway.mp3" },
-      { name: "Tamachi",        mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/tamachi-announcement.mp3",     mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Tamachi.mp3" },
-      { name: "Hamamatsucho",   mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/hamamatsucho-announcement.mp3", mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Hamamatsucho.mp3" },
-      { name: "Shimbashi",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/shimbashi-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Shimbashi.mp3" },
-      { name: "Yurakucho",      mp3Announcement: "https://madewithonlyai.com/Sites/yamanoteline/announcements/yurakucho-announcement.mp3",   mp3Station: "https://madewithonlyai.com/Sites/yamanoteline/sounds/Yurakucho.mp3" }
-    ];
-    
-    let currentStationIndex = -1;
-    let announcementVolume = 1, stationVolume = 1;
-    let announcementMuted = false, stationMuted = false;
-    let currentAudioType = "";
-    let playDirection = 1; // +1 clockwise, -1 counterclockwise
+const STATIONS = [
+  {
+    id: 'tokyo',
+    name: 'Tokyo',
+    japaneseName: '東京',
+    about:
+      "Tokyo Station anchors Japan's capital with its red-brick Marunouchi facade and bustling underground concourses. Marunouchi and Nihonbashi surround the hub with flagship stores, refined dining, and the Imperial Palace gardens just a short stroll away.",
+    background:
+      'https://images.unsplash.com/photo-1549692520-acc6669e2f0c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo Line (Rapid)', code: 'JC', color: '#f15a24', operator: 'JR East' },
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'Tokaido Shinkansen', code: '🚄', color: '#1b5e20', operator: 'JR Central' },
+      { name: 'Tokyo Metro Marunouchi Line', code: 'M', color: '#c62828', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/tokyo-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Tokyo.mp3"
+  },
+  {
+    id: 'kanda',
+    name: 'Kanda',
+    japaneseName: '神田',
+    about:
+      "Kanda blends old-world wholesalers with a growing tech crowd, filling the side streets with retro coffee shops and lively izakaya. Students from nearby universities keep the district energetic well into the night.",
+    background:
+      'https://images.unsplash.com/photo-1512455102795-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo Line (Rapid)', code: 'JC', color: '#f15a24', operator: 'JR East' },
+      { name: 'Tokyo Metro Ginza Line', code: 'G', color: '#f9a825', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/kanda-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Kanda.mp3"
+  },
+  {
+    id: 'akihabara',
+    name: 'Akihabara',
+    japaneseName: '秋葉原',
+    about:
+      'Electric Town dazzles with towering anime billboards, electronics megastores, and specialty game shops. From maid cafés to retro arcades, Akihabara celebrates subculture and tech innovation on every block.',
+    background:
+      'https://images.unsplash.com/photo-1518548419970-58e3b4079ab2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Sobu Line', code: 'JB', color: '#f6b27b', operator: 'JR East' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' },
+      { name: 'Tsukuba Express', code: 'TX', color: '#5c6bc0', operator: 'Metropolitan Intercity Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/akihabara-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Akihabara.mp3"
+  },
+  {
+    id: 'okachimachi',
+    name: 'Okachimachi',
+    japaneseName: '御徒町',
+    about:
+      "Okachimachi connects the open-air stalls of Ameya-Yokocho with polished jewelry boutiques under the tracks. The neighborhood's mix of street eats and craft workshops makes it a favorite for treasure hunters.",
+    background:
+      'https://images.unsplash.com/photo-1542051841857-5f90071e7989?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/okachimachi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Okachimachi.mp3"
+  },
+  {
+    id: 'ueno',
+    name: 'Ueno',
+    japaneseName: '上野',
+    about:
+      "Ueno is Tokyo's cultural commons, where national museums line the edges of Ueno Park and street food fills Ameyoko market. Springtime hanami crowds gather beneath the park's famous cherry blossoms.",
+    background:
+      'https://images.unsplash.com/photo-1503899036084-c55cdd92da26?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Utsunomiya Line', code: 'JU', color: '#f57c00', operator: 'JR East' },
+      { name: 'JR Joban Line', code: 'JJ', color: '#00796b', operator: 'JR East' },
+      { name: 'Tokyo Metro Ginza Line', code: 'G', color: '#f9a825', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' },
+      { name: 'Keisei Main Line', code: 'KS', color: '#1a73e8', operator: 'Keisei Electric Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/ueno-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Ueno.mp3"
+  },
+  {
+    id: 'uguisudani',
+    name: 'Uguisudani',
+    japaneseName: '鶯谷',
+    about:
+      "Named for the warbling nightingales once heard here, Uguisudani now offers quiet residential lanes beside small museums and Showa-era cafés. The gentle hillside views contrast with the bustle of nearby Ueno.",
+    background:
+      'https://images.unsplash.com/photo-1542038791-0d9df90f6a5a?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/uguisudani-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Uguisudani.mp3"
+  },
+  {
+    id: 'nippori',
+    name: 'Nippori',
+    japaneseName: '日暮里',
+    about:
+      "Nippori bridges tradition and creativity, with Yanaka's old temples on one side and the fabric district's rainbow bolts on the other. Travelers connect here to reach Narita via the Keisei Skyliner.",
+    background:
+      'https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'JR Joban Line', code: 'JJ', color: '#00796b', operator: 'JR East' },
+      { name: 'Keisei Skyliner', code: 'KS', color: '#1a73e8', operator: 'Keisei Electric Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/nippori-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Nippori.mp3"
+  },
+  {
+    id: 'nishi-nippori',
+    name: 'Nishi-Nippori',
+    japaneseName: '西日暮里',
+    about:
+      "Residential towers and neighborhood ramen counters define Nishi-Nippori. It is a convenient interchange linking the Chiyoda Line and the Nippori-Toneri Liner to Tokyo's northeastern suburbs.",
+    background:
+      'https://images.unsplash.com/photo-1517638851339-4aa32003c11a?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Chiyoda Line', code: 'C', color: '#009688', operator: 'Tokyo Metro' },
+      { name: 'Nippori-Toneri Liner', code: 'NT', color: '#43a047', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/nishinippori-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Nishinippori.mp3"
+  },
+  {
+    id: 'tabata',
+    name: 'Tabata',
+    japaneseName: '田端',
+    about:
+      "Tabata sits atop a ridge with long-established residential streets and views over the Sumida River rail yards. It is a practical stop for commuters heading toward Saitama and northern Tokyo.",
+    background:
+      'https://images.unsplash.com/photo-1566977744263-0bb0048e9b25?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/tabata-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Tabata.mp3"
+  },
+  {
+    id: 'komagome',
+    name: 'Komagome',
+    japaneseName: '駒込',
+    about:
+      'Komagome is famed for Rikugien Garden, a classical landscaped retreat glowing with autumn maples and spring azaleas. Shopping arcades by the station serve fresh wagashi and tea to strolling visitors.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Namboku Line', code: 'N', color: '#26a69a', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/komagome-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Komagome.mp3"
+  },
+  {
+    id: 'sugamo',
+    name: 'Sugamo',
+    japaneseName: '巣鴨',
+    about:
+      'Nicknamed the “Harajuku for grandmas,” Sugamo\'s Jizo-dori shopping street bustles with red underwear shops, sweets stalls, and pilgrims to Koganji Temple. Seasonal festivals keep the retro atmosphere lively.',
+    background:
+      'https://images.unsplash.com/photo-1529921879218-f9956cc87d77?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Toei Mita Line', code: 'I', color: '#1565c0', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/sugamo-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Sugamo.mp3"
+  },
+  {
+    id: 'otsuka',
+    name: 'Otsuka',
+    japaneseName: '大塚',
+    about:
+      "Otsuka mixes vintage tram charm with a wave of new cafés and craft beer bars. The Tokyo Sakura Tram still trundles past the station, connecting quiet residential pockets in northern Tokyo.",
+    background:
+      'https://images.unsplash.com/photo-1518378188025-22bd89516ee2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Sakura Tram (Toden Arakawa Line)', code: 'SA', color: '#ec407a', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/otsuka-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Otsuka.mp3"
+  },
+  {
+    id: 'ikebukuro',
+    name: 'Ikebukuro',
+    japaneseName: '池袋',
+    about:
+      'Ikebukuro is a mega terminal anchored by Sunshine City, anime boutiques, and rooftop observatories. West Gate Park and student-filled diners keep the area buzzing day and night.',
+    background:
+      'https://images.unsplash.com/photo-1528164344705-47542687000d?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Tokyo Metro Marunouchi Line', code: 'M', color: '#c62828', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Fukutoshin Line', code: 'F', color: '#6d4c41', operator: 'Tokyo Metro' },
+      { name: 'Seibu Ikebukuro Line', code: 'SI', color: '#2196f3', operator: 'Seibu Railway' },
+      { name: 'Tobu Tojo Line', code: 'TJ', color: '#ff7043', operator: 'Tobu Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/ikebukuro-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Ikebukuro.mp3"
+  },
+  {
+    id: 'mejiro',
+    name: 'Mejiro',
+    japaneseName: '目白',
+    about:
+      'Leafy Mejiro is defined by Gakushuin University and tranquil residential streets lined with embassies. Charming bakeries and bookshops cluster around the compact station.',
+    background:
+      'https://images.unsplash.com/photo-1518860308377-0d91b5a7bb1c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [],
+    mp3Announcement: "Sites/yamanoteline/announcements/mejiro-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Mejiro.mp3"
+  },
+  {
+    id: 'takadanobaba',
+    name: 'Takadanobaba',
+    japaneseName: '高田馬場',
+    about:
+      'Takadanobaba pulses with student energy thanks to Waseda University. Retro game centers, budget eats, and jazz bars line the streets, while the Astro Boy theme plays as the station melody.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Tozai Line', code: 'T', color: '#0288d1', operator: 'Tokyo Metro' },
+      { name: 'Seibu Shinjuku Line', code: 'SS', color: '#388e3c', operator: 'Seibu Railway' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/takadanobaba-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Takadanobaba.mp3"
+  },
+  {
+    id: 'shin-okubo',
+    name: 'Shin-Okubo',
+    japaneseName: '新大久保',
+    about:
+      "Tokyo's Koreatown thrives in Shin-Okubo with neon-lit restaurants, K-pop boutiques, and dessert cafés. The multicultural streets stay lively late into the evening.",
+    background:
+      'https://images.unsplash.com/photo-1503899036084-c55cdd92da26?auto=format&fit=crop&w=1600&q=80',
+    transfers: [],
+    mp3Announcement: "Sites/yamanoteline/announcements/shinokubo-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shinokubo.mp3"
+  },
+  {
+    id: 'shinjuku',
+    name: 'Shinjuku',
+    japaneseName: '新宿',
+    about:
+      "Shinjuku Station is the world's busiest, funneling travelers to skyscraper canyons, Kabukicho nightlife, and the calm greenery of Shinjuku Gyoen. Observation decks offer sweeping views over Tokyo.",
+    background:
+      'https://images.unsplash.com/photo-1478432780021-b8d273730d8c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo Line (Rapid)', code: 'JC', color: '#f15a24', operator: 'JR East' },
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Tokyo Metro Marunouchi Line', code: 'M', color: '#c62828', operator: 'Tokyo Metro' },
+      { name: 'Toei Oedo Line', code: 'E', color: '#7b1fa2', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shinjuku-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shinjuku.mp3"
+  },
+  {
+    id: 'yoyogi',
+    name: 'Yoyogi',
+    japaneseName: '代々木',
+    about:
+      'Yoyogi balances quiet offices with access to Yoyogi Park and the towering National Gymnasium. Art schools and climbing gyms keep the youthful spirit alive around the station.',
+    background:
+      'https://images.unsplash.com/photo-1545569341-9eb8b30979d8?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Chuo-Sobu Line', code: 'JB', color: '#f6b27b', operator: 'JR East' },
+      { name: 'Toei Oedo Line', code: 'E', color: '#7b1fa2', operator: 'Toei' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/yoyogi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Yoyogi.mp3"
+  },
+  {
+    id: 'harajuku',
+    name: 'Harajuku',
+    japaneseName: '原宿',
+    about:
+      "Harajuku is a playground for street fashion, from Takeshita Street's pop culture boutiques to Omotesando's flagship architecture. The leafy Meiji Shrine grounds offer a quiet counterpoint nearby.",
+    background:
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Chiyoda Line (Meiji-jingumae)', code: 'C', color: '#009688', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Fukutoshin Line', code: 'F', color: '#6d4c41', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/harajuku-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Harajuku.mp3"
+  },
+  {
+    id: 'shibuya',
+    name: 'Shibuya',
+    japaneseName: '渋谷',
+    about:
+      'Shibuya Crossing pulses with neon billboards, music, and constant foot traffic. The district blends next-generation retail, creative agencies, and late-night entertainment that define modern Tokyo.',
+    background:
+      'https://images.unsplash.com/photo-1518548419970-58e3b4079ab2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'JR Shonan-Shinjuku Line', code: 'JS', color: '#ef5350', operator: 'JR East' },
+      { name: 'Tokyo Metro Ginza Line', code: 'G', color: '#f9a825', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Hanzomon Line', code: 'Z', color: '#7b1fa2', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Fukutoshin Line', code: 'F', color: '#6d4c41', operator: 'Tokyo Metro' },
+      { name: 'Tokyu Den-en-toshi Line', code: 'DT', color: '#00897b', operator: 'Tokyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shibuya-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shibuya.mp3"
+  },
+  {
+    id: 'ebisu',
+    name: 'Ebisu',
+    japaneseName: '恵比寿',
+    about:
+      'Ebisu offers refined dining, craft beer bars, and the Yebisu Garden Place promenade. Brick arcades, photography museums, and relaxed terraces give the area an elegant urban village feel.',
+    background:
+      'https://images.unsplash.com/photo-1478432780021-b8d273730d8c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/ebisu-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Ebisu.mp3"
+  },
+  {
+    id: 'meguro',
+    name: 'Meguro',
+    japaneseName: '目黒',
+    about:
+      "Meguro's tree-lined avenues lead to specialty coffee shops, design studios, and the serene Meguro River. Spring cherry blossoms transform the riverside into a soft pink tunnel.",
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Namboku Line', code: 'N', color: '#26a69a', operator: 'Tokyo Metro' },
+      { name: 'Toei Mita Line', code: 'I', color: '#1565c0', operator: 'Toei' },
+      { name: 'Tokyu Meguro Line', code: 'MG', color: '#795548', operator: 'Tokyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/meguro-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Meguro.mp3"
+  },
+  {
+    id: 'gotanda',
+    name: 'Gotanda',
+    japaneseName: '五反田',
+    about:
+      'Gotanda mixes riverside offices with late-night eateries and karaoke lounges. Local izakaya clusters under the elevated tracks while megabanks loom overhead.',
+    background:
+      'https://images.unsplash.com/photo-1518548419970-58e3b4079ab2?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Toei Asakusa Line', code: 'A', color: '#e53935', operator: 'Toei' },
+      { name: 'Tokyu Ikegami Line', code: 'IK', color: '#ff7043', operator: 'Tokyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/gotanda-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Gotanda.mp3"
+  },
+  {
+    id: 'osaki',
+    name: 'Osaki',
+    japaneseName: '大崎',
+    about:
+      "Redeveloped Osaki is home to tech offices, open plazas, and elevated walkways that connect Shinagawa's business zone. Art installations dot the corporate campuses.",
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Saikyo Line', code: 'JA', color: '#4caf50', operator: 'JR East' },
+      { name: 'Rinkai Line', code: 'R', color: '#3949ab', operator: 'Tokyo Waterfront Area Rapid Transit' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/osaki-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Osaki.mp3"
+  },
+  {
+    id: 'shinagawa',
+    name: 'Shinagawa',
+    japaneseName: '品川',
+    about:
+      "Shinagawa links Tokyo to the south with Shinkansen platforms, waterfront hotels, and the historic Tokaido road. High-rise offices and aquarium attractions make it a major gateway.",
+    background:
+      'https://images.unsplash.com/photo-1478432780021-b8d273730d8c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'JR Tokaido Line', code: 'JT', color: '#f57c00', operator: 'JR East' },
+      { name: 'Tokaido Shinkansen', code: '🚄', color: '#1b5e20', operator: 'JR Central' },
+      { name: 'Keikyu Main Line', code: 'KK', color: '#d32f2f', operator: 'Keikyu Corporation' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shinagawa-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shinagawa.mp3"
+  },
+  {
+    id: 'takanawa-gateway',
+    name: 'Takanawa Gateway',
+    japaneseName: '高輪ゲートウェイ',
+    about:
+      'Takanawa Gateway is the newest Yamanote station, with a light-filled design by architect Kengo Kuma. Emerging smart-city developments surround the spacious concourse.',
+    background:
+      'https://images.unsplash.com/photo-1554797589-7241bb691973?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/takanawagateway-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/TakanawaGateway.mp3"
+  },
+  {
+    id: 'tamachi',
+    name: 'Tamachi',
+    japaneseName: '田町',
+    about:
+      'Tamachi links office towers with the canalside campus of Keio University. Elevated promenades lead toward the redeveloped Shibaura waterfront and tiny yakitori bars under the tracks.',
+    background:
+      'https://images.unsplash.com/photo-1549692520-acc6669e2f0c?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/tamachi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Tamachi.mp3"
+  },
+  {
+    id: 'hamamatsucho',
+    name: 'Hamamatsucho',
+    japaneseName: '浜松町',
+    about:
+      "Hamamatsucho connects to Haneda Airport via the Tokyo Monorail and sits beside the iconic Tokyo Tower. Zojoji Temple and waterfront gardens offer moments of calm in the business district.",
+    background:
+      'https://images.unsplash.com/photo-1512455102795-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'Tokyo Monorail', code: 'MO', color: '#0288d1', operator: 'Tokyo Monorail' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/hamamatsucho-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Hamamatsucho.mp3"
+  },
+  {
+    id: 'shimbashi',
+    name: 'Shimbashi',
+    japaneseName: '新橋',
+    about:
+      "Salarymen gather in Shimbashi's lantern-lit alleys after work, while corporate media towers rise above. The station is the historic birthplace of Japan's first railway terminal.",
+    background:
+      'https://images.unsplash.com/photo-1554797589-7241bb691973?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'JR Keihin-Tohoku Line', code: 'JK', color: '#00bcd4', operator: 'JR East' },
+      { name: 'Toei Asakusa Line', code: 'A', color: '#e53935', operator: 'Toei' },
+      { name: 'Toei Oedo Line', code: 'E', color: '#7b1fa2', operator: 'Toei' },
+      { name: 'Yurikamome Line', code: 'U', color: '#26c6da', operator: 'Yurikamome Inc.' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/shimbashi-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Shimbashi.mp3"
+  },
+  {
+    id: 'yurakucho',
+    name: 'Yurakucho',
+    japaneseName: '有楽町',
+    about:
+      'Yurakucho combines upscale Ginza shopping with Showa-era yakitori alleys tucked under the viaducts. The Tokyo International Forum's glass canopy hosts design fairs and concerts year-round.',
+    background:
+      'https://images.unsplash.com/photo-1526481280695-3d1d229e2b6f?auto=format&fit=crop&w=1600&q=80',
+    transfers: [
+      { name: 'Tokyo Metro Yurakucho Line', code: 'Y', color: '#fdd835', operator: 'Tokyo Metro' },
+      { name: 'Tokyo Metro Hibiya Line', code: 'H', color: '#9e9d24', operator: 'Tokyo Metro' }
+    ],
+    mp3Announcement: "Sites/yamanoteline/announcements/yurakucho-announcement.mp3",
+    mp3Station: "Sites/yamanoteline/sounds/Yurakucho.mp3"
+  }
+];
 
-    const audioElement = document.getElementById("audio");
-    const currentStationLabel = document.getElementById("currentStation");
-    const skipAnnouncementToggle = document.getElementById("skipAnnouncement");
-    const directionToggle = document.getElementById("directionToggle");
-    const directionText = document.getElementById("directionText");
-    const darkModeToggle = document.getElementById("darkModeToggle");
-    const darkModeText = document.getElementById("darkModeText");
-    const layoutToggle = document.getElementById("layoutToggle");
-    const playPauseBtn = document.getElementById("playPauseBtn");
+const elements = {
+  viewport: document.getElementById('stationViewport'),
+  background: document.getElementById('stationBackground'),
+  nameJp: document.getElementById('stationNameJp'),
+  nameEn: document.getElementById('stationNameEn'),
+  about: document.getElementById('stationAbout'),
+  transferList: document.getElementById('transferLines'),
+  prevPreview: document.getElementById('prevStationPreview'),
+  nextPreview: document.getElementById('nextStationPreview'),
+  playPause: document.getElementById('playPause'),
+  skip: document.getElementById('skipStation'),
+  volume: document.getElementById('volumeSlider'),
+  mute: document.getElementById('muteButton'),
+  trackLabel: document.getElementById('currentTrackLabel'),
+  rideMode: document.getElementById('rideModeButton'),
+  ambientToggle: document.getElementById('ambientToggle'),
+  mapToggle: document.getElementById('mapToggle'),
+  mobileMap: document.getElementById('mobileMap'),
+  mobilePlay: document.getElementById('mobilePlay'),
+  mobileSkip: document.getElementById('mobileSkip'),
+  mapOverlay: document.getElementById('mapOverlay'),
+  closeMap: document.getElementById('closeMap'),
+  loopMap: document.getElementById('loopMap'),
+  searchInput: document.getElementById('stationSearch'),
+  jumpButton: document.getElementById('jumpButton'),
+  datalist: document.getElementById('stationList'),
+  announcementAudio: document.getElementById('announcementAudio'),
+  ambientAudio: document.getElementById('ambientAudio')
+};
 
-    // Dark mode toggle
-    darkModeToggle.addEventListener("change", () => {
-      if (darkModeToggle.checked) {
-        document.body.classList.add("dark-mode");
-        darkModeText.textContent = "Dark Mode";
-      } else {
-        document.body.classList.remove("dark-mode");
-        darkModeText.textContent = "Light Mode";
-      }
-    });
+const MEDIA_PREFIX = 'Sites/yamanoteline/';
 
-    // Layout toggle button
-    layoutToggle.addEventListener("click", () => {
-      if (document.body.classList.contains("modern-layout")) {
-        document.body.classList.remove("modern-layout");
-        layoutToggle.textContent = "Switch Layout";
-        localStorage.setItem("layout", "classic");
-        // Reposition stations for circle layout
-        placeStations();
-        generateArrows();
-        updateArrowAnimation();
-      } else {
-        document.body.classList.add("modern-layout");
-        layoutToggle.textContent = "Classic Layout";
-        localStorage.setItem("layout", "modern");
-        // Clear arrows when in modern layout
-        document.getElementById("arrowContainer").innerHTML = "";
-        // Rebuild station list without positioning
-        const stationsContainer = document.getElementById("stations");
-        stationsContainer.innerHTML = "";
-        stations.forEach((st, i) => {
-          const div = document.createElement("div");
-          div.classList.add("station");
-          div.textContent = st.name;
-          div.dataset.index = i;
-          div.addEventListener("click", () => playStation(i));
-          stationsContainer.appendChild(div);
-        });
-      }
-    });
+const STORAGE_KEYS = {
+  volume: 'yamanote-volume',
+  rideMode: 'yamanote-ride-mode',
+  ambient: 'yamanote-ambient',
+  muted: 'yamanote-muted'
+};
 
-    // Log audio errors
-    audioElement.addEventListener("error", () => {
-      console.error("Audio error:", audioElement.error);
-    });
+const state = {
+  index: 0,
+  rideMode: true,
+  playing: false,
+  muted: false,
+  ambient: false,
+  scrollLock: false,
+  touchStartY: null
+};
 
-    // Update active station button style
-    function updateActiveStation(index, mode) {
-      document.querySelectorAll(".station").forEach(el => {
-        el.classList.remove("announcement-active", "station-active");
+let endedNaturally = false;
+
+function toLocalPath(path) {
+  return path.startsWith(MEDIA_PREFIX) ? path.slice(MEDIA_PREFIX.length) : path;
+}
+
+function clampIndex(index) {
+  const total = STATIONS.length;
+  return ((index % total) + total) % total;
+}
+
+function updateBackground(url) {
+  elements.background.style.backgroundImage = url ? `url(${url})` : 'none';
+}
+
+function buildPreviewMarkup(station, label, arrow) {
+  return `
+    <div class="station-preview__inner">
+      <span class="station-preview__direction">${arrow} ${label}</span>
+      <span class="station-preview__jp" lang="ja">${station.japaneseName}</span>
+      <span class="station-preview__en">${station.name}</span>
+    </div>
+  `;
+}
+
+function updatePreviews() {
+  const previous = STATIONS[clampIndex(state.index - 1)];
+  const next = STATIONS[clampIndex(state.index + 1)];
+
+  elements.prevPreview.innerHTML = buildPreviewMarkup(previous, 'Previous', '▲');
+  elements.nextPreview.innerHTML = buildPreviewMarkup(next, 'Next', '▼');
+  elements.prevPreview.setAttribute('aria-hidden', 'false');
+  elements.nextPreview.setAttribute('aria-hidden', 'false');
+}
+
+function clearChildren(node) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function renderTransfers(station) {
+  clearChildren(elements.transferList);
+
+  if (!station.transfers.length) {
+    const empty = document.createElement('p');
+    empty.className = 'transfer-lines__empty';
+    empty.textContent = 'No direct transfers';
+    elements.transferList.appendChild(empty);
+    return;
+  }
+
+  station.transfers.forEach((transfer) => {
+    const chip = document.createElement('span');
+    chip.className = 'transfer-chip';
+    chip.title = transfer.operator;
+
+    const badge = document.createElement('span');
+    badge.className = 'transfer-chip__icon';
+    badge.textContent = transfer.code;
+    badge.style.background = transfer.color;
+    chip.appendChild(badge);
+
+    const label = document.createElement('span');
+    label.className = 'transfer-chip__name';
+    label.textContent = transfer.name;
+    chip.appendChild(label);
+
+    elements.transferList.appendChild(chip);
+  });
+}
+
+function updateTrackLabel(status) {
+  const station = STATIONS[state.index];
+  elements.trackLabel.textContent = `${status} • ${station.name}`;
+}
+
+function syncPlayButtons() {
+  const symbol = state.playing ? '⏸' : '▶';
+  elements.playPause.textContent = symbol;
+  elements.playPause.setAttribute('aria-pressed', String(state.playing));
+  if (elements.mobilePlay) {
+    elements.mobilePlay.textContent = symbol;
+    elements.mobilePlay.setAttribute('aria-pressed', String(state.playing));
+  }
+}
+
+function syncMuteButton() {
+  elements.mute.textContent = state.muted ? 'Unmute' : 'Mute';
+  elements.mute.setAttribute('aria-pressed', String(state.muted));
+}
+
+function syncRideModeButton() {
+  elements.rideMode.textContent = state.rideMode ? 'Ride Mode On' : 'Ride Mode Off';
+  elements.rideMode.setAttribute('aria-pressed', String(state.rideMode));
+}
+
+function syncAmbientButton() {
+  elements.ambientToggle.textContent = state.ambient ? 'Ambient On' : 'Ambient Off';
+  elements.ambientToggle.setAttribute('aria-pressed', String(state.ambient));
+}
+
+function syncMapButtons(isOpen) {
+  elements.mapToggle.setAttribute('aria-expanded', String(isOpen));
+  if (elements.mobileMap) {
+    elements.mobileMap.setAttribute('aria-expanded', String(isOpen));
+  }
+  elements.mapOverlay.setAttribute('aria-hidden', String(!isOpen));
+}
+
+function highlightMapNode() {
+  const nodes = elements.loopMap.querySelectorAll('.map-node');
+  nodes.forEach((node, index) => {
+    node.classList.toggle('is-active', index === state.index);
+  });
+}
+
+function prepareAnnouncementSource() {
+  const station = STATIONS[state.index];
+  const src = `${toLocalPath(station.mp3Announcement)}${CACHE_BUST}`;
+  if (elements.announcementAudio.dataset.src !== src) {
+    elements.announcementAudio.dataset.src = src;
+    elements.announcementAudio.src = src;
+  }
+}
+
+function goToStation(index, { play = false } = {}) {
+  state.index = clampIndex(index);
+  const station = STATIONS[state.index];
+
+  elements.announcementAudio.pause();
+  prepareAnnouncementSource();
+
+  updateBackground(station.background);
+  elements.background.setAttribute('aria-label', `${station.name} station background`);
+  elements.nameJp.textContent = station.japaneseName;
+  elements.nameEn.textContent = station.name;
+  elements.about.textContent = station.about;
+  renderTransfers(station);
+  updatePreviews();
+  highlightMapNode();
+  updateTrackLabel(play ? 'Loading' : 'Ready');
+
+  if (play) {
+    playCurrent();
+  } else {
+    state.playing = false;
+    syncPlayButtons();
+  }
+}
+
+function playCurrent() {
+  prepareAnnouncementSource();
+  const playPromise = elements.announcementAudio.play();
+  if (playPromise && typeof playPromise.then === 'function') {
+    playPromise
+      .then(() => {
+        state.playing = true;
+        updateTrackLabel('Playing');
+        syncPlayButtons();
+      })
+      .catch(() => {
+        state.playing = false;
+        updateTrackLabel('Ready');
+        syncPlayButtons();
       });
-      const stationButton = document.querySelector(`.station[data-index="${index}"]`);
-      if (stationButton) {
-        if (mode === "announcement") {
-          stationButton.classList.add("announcement-active");
-        } else if (mode === "station") {
-          stationButton.classList.add("station-active");
-        }
-      }
-    }
+  } else {
+    state.playing = true;
+    updateTrackLabel('Playing');
+    syncPlayButtons();
+  }
+}
 
-    // Update play/pause button icon
-    function updatePlayPauseIcon() {
-      playPauseBtn.textContent = audioElement.paused ? "▶" : "⏸";
-    }
-    audioElement.addEventListener("play", updatePlayPauseIcon);
-    audioElement.addEventListener("pause", updatePlayPauseIcon);
+function pauseCurrent(updateLabel = true) {
+  elements.announcementAudio.pause();
+  state.playing = false;
+  if (updateLabel) {
+    updateTrackLabel('Paused');
+  }
+  syncPlayButtons();
+}
 
-    // Generate inner arrow circle
-    function generateArrows() {
-      const arrowContainer = document.getElementById("arrowContainer");
-      arrowContainer.innerHTML = "";
-      const containerWidth = arrowContainer.offsetWidth;
-      const containerHeight = arrowContainer.offsetHeight;
-      const centerX = containerWidth / 2;
-      const centerY = containerHeight / 2;
-      const arrowRadius = 300;
-      const numArrows = 50;
-      for (let i = 0; i < numArrows; i++) {
-        const angle = (2 * Math.PI * i) / numArrows;
-        const x = centerX + arrowRadius * Math.cos(angle);
-        const y = centerY + arrowRadius * Math.sin(angle);
+function changeStation(delta, { auto = false } = {}) {
+  const shouldPlay = auto ? state.rideMode : state.playing;
+  goToStation(state.index + delta, { play: shouldPlay });
+}
 
-        const arrow = document.createElement("div");
-        arrow.classList.add("arrow");
-        arrow.textContent = "➤";
-        arrow.style.left = x + "px";
-        arrow.style.top = y + "px";
-        const angleDeg = (angle * 180) / Math.PI;
-        const rotationDeg = (playDirection === 1) ? angleDeg + 90 : angleDeg - 90;
-        arrow.style.transform = `translate(-50%, -50%) rotate(${rotationDeg}deg)`;
-        arrowContainer.appendChild(arrow);
-      }
-    }
+function handlePlayToggle() {
+  if (state.playing) {
+    pauseCurrent();
+  } else {
+    playCurrent();
+  }
+}
 
-    function updateArrowAnimation() {
-      const arrowContainer = document.getElementById("arrowContainer");
-      arrowContainer.style.animationName =
-        (playDirection === 1) ? "spinClockwise" : "spinCounterClockwise";
-      generateArrows();
-    }
+function toggleRideMode() {
+  state.rideMode = !state.rideMode;
+  localStorage.setItem(STORAGE_KEYS.rideMode, String(state.rideMode));
+  syncRideModeButton();
+}
 
-    // Place stations on outer circle
-    function placeStations() {
-      const stationsContainer = document.getElementById("stations");
-      stationsContainer.innerHTML = "";
-      const containerWidth = stationsContainer.offsetWidth;
-      const containerHeight = stationsContainer.offsetHeight;
-      const centerX = containerWidth / 2;
-      const centerY = containerHeight / 2;
-      const stationRadius = 380;
-      const totalStations = stations.length;
-
-      for (let i = 0; i < totalStations; i++) {
-        const angle = (2 * Math.PI * i) / totalStations - Math.PI / 2;
-        const x = centerX + stationRadius * Math.cos(angle);
-        const y = centerY + stationRadius * Math.sin(angle);
-
-        const stationDiv = document.createElement("div");
-        stationDiv.classList.add("station");
-        stationDiv.textContent = stations[i].name;
-        stationDiv.style.left = x + "px";
-        stationDiv.style.top = y + "px";
-        stationDiv.dataset.index = i;
-        stationDiv.addEventListener("click", () => {
-          playStation(i);
-        });
-        stationsContainer.appendChild(stationDiv);
-      }
-    }
-
-    // Playback logic
-    function playStation(index) {
-      currentStationIndex = index;
-      const station = stations[index];
-      audioElement.onended = null;
-      updateActiveStation(index, "");
-
-      // If skip announcements is OFF, play announcement first
-      if (!skipAnnouncementToggle.checked) {
-        currentAudioType = "announcement";
-        currentStationLabel.textContent = station.name + " (announcement)";
-        audioElement.src = station.mp3Announcement + cacheBust;
-        audioElement.volume = announcementMuted ? 0 : announcementVolume;
-        audioElement.play().then(() => {
-          updateActiveStation(index, "announcement");
-          audioElement.onended = () => {
-            playStationAudio(station);
-          };
-        }).catch(err => {
-          console.error("Announcement playback failed:", err);
-          playStationAudio(station);
-        });
-      } else {
-        // Skip announcements
-        playStationAudio(station);
-      }
-    }
-
-    function playStationAudio(station) {
-      currentAudioType = "station";
-      currentStationLabel.textContent = station.name;
-      audioElement.src = station.mp3Station + cacheBust;
-      audioElement.volume = stationMuted ? 0 : stationVolume;
-      audioElement.play().then(() => {
-        updateActiveStation(currentStationIndex, "station");
-        audioElement.onended = () => {
-          nextStation();
-        };
-      }).catch(err => {
-        console.error("Station playback failed:", err);
+function toggleAmbient() {
+  state.ambient = !state.ambient;
+  localStorage.setItem(STORAGE_KEYS.ambient, String(state.ambient));
+  if (state.ambient) {
+    elements.ambientAudio.volume = 0.25;
+    elements.ambientAudio
+      .play()
+      .catch(() => {
+        state.ambient = false;
+        localStorage.setItem(STORAGE_KEYS.ambient, 'false');
+      })
+      .finally(() => {
+        syncAmbientButton();
       });
+  } else {
+    elements.ambientAudio.pause();
+    syncAmbientButton();
+  }
+}
+
+function toggleMap(force) {
+  const isOpen = typeof force === 'boolean'
+    ? force
+    : !elements.mapOverlay.classList.contains('map-overlay--active');
+
+  elements.mapOverlay.classList.toggle('map-overlay--active', isOpen);
+  syncMapButtons(isOpen);
+
+  if (isOpen) {
+    highlightMapNode();
+    const activeNode = elements.loopMap.querySelector(`.map-node[data-index="${state.index}"]`);
+    activeNode?.focus({ preventScroll: true });
+  } else {
+    elements.mapToggle.focus({ preventScroll: true });
+  }
+}
+
+function buildSearchOptions() {
+  clearChildren(elements.datalist);
+  STATIONS.forEach((station) => {
+    const optionEn = document.createElement('option');
+    optionEn.value = station.name;
+    optionEn.label = station.japaneseName;
+    elements.datalist.appendChild(optionEn);
+
+    const optionJp = document.createElement('option');
+    optionJp.value = station.japaneseName;
+    optionJp.label = station.name;
+    elements.datalist.appendChild(optionJp);
+  });
+}
+
+function buildMap() {
+  const svgNS = 'http://www.w3.org/2000/svg';
+  elements.loopMap.innerHTML = '';
+
+  const path = document.createElementNS(svgNS, 'circle');
+  path.setAttribute('cx', '300');
+  path.setAttribute('cy', '300');
+  path.setAttribute('r', '220');
+  path.classList.add('loop-path');
+  elements.loopMap.appendChild(path);
+
+  const radius = 220;
+  const labelRadius = radius + 32;
+  const center = 300;
+
+  STATIONS.forEach((station, index) => {
+    const angle = (2 * Math.PI * index) / STATIONS.length - Math.PI / 2;
+    const x = center + radius * Math.cos(angle);
+    const y = center + radius * Math.sin(angle);
+    const lx = center + labelRadius * Math.cos(angle);
+    const ly = center + labelRadius * Math.sin(angle);
+
+    const node = document.createElementNS(svgNS, 'g');
+    node.classList.add('map-node');
+    node.dataset.index = String(index);
+    node.setAttribute('role', 'button');
+    node.setAttribute('tabindex', '0');
+    node.setAttribute('aria-label', `Jump to ${station.name}`);
+
+    const dot = document.createElementNS(svgNS, 'circle');
+    dot.setAttribute('cx', x.toFixed(2));
+    dot.setAttribute('cy', y.toFixed(2));
+    dot.setAttribute('r', '10');
+    node.appendChild(dot);
+
+    const label = document.createElementNS(svgNS, 'text');
+    label.setAttribute('x', lx.toFixed(2));
+    label.setAttribute('y', ly.toFixed(2));
+    label.setAttribute('text-anchor', 'middle');
+    label.setAttribute('dominant-baseline', 'middle');
+    label.textContent = station.name;
+    node.appendChild(label);
+
+    node.addEventListener('click', () => {
+      toggleMap(false);
+      goToStation(index, { play: state.playing });
+    });
+
+    node.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleMap(false);
+        goToStation(index, { play: state.playing });
+      }
+    });
+
+    elements.loopMap.appendChild(node);
+  });
+
+  highlightMapNode();
+}
+
+function findStationIndex(query) {
+  if (!query) {
+    return -1;
+  }
+
+  const normalized = query.trim().toLowerCase();
+  return STATIONS.findIndex((station) => {
+    return (
+      station.name.toLowerCase() === normalized ||
+      station.japaneseName === query.trim() ||
+      station.name.toLowerCase().includes(normalized) ||
+      station.japaneseName.includes(query.trim())
+    );
+  });
+}
+
+function handleSearchJump() {
+  const query = elements.searchInput.value;
+  const targetIndex = findStationIndex(query);
+  if (targetIndex >= 0) {
+    goToStation(targetIndex, { play: state.playing });
+  }
+}
+
+function handleWheel(event) {
+  if (state.scrollLock) {
+    return;
+  }
+
+  if (Math.abs(event.deltaY) > 40) {
+    state.scrollLock = true;
+    changeStation(event.deltaY > 0 ? 1 : -1);
+    setTimeout(() => {
+      state.scrollLock = false;
+    }, 650);
+  }
+}
+
+function handleTouchStart(event) {
+  state.touchStartY = event.touches[0]?.clientY ?? null;
+}
+
+function handleTouchEnd(event) {
+  if (state.touchStartY === null) {
+    return;
+  }
+  const delta = state.touchStartY - (event.changedTouches[0]?.clientY ?? state.touchStartY);
+  state.touchStartY = null;
+  if (Math.abs(delta) > 45) {
+    changeStation(delta > 0 ? 1 : -1);
+  }
+}
+
+function handleKeyNavigation(event) {
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      event.preventDefault();
+      changeStation(1);
+      break;
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      event.preventDefault();
+      changeStation(-1);
+      break;
+    case ' ': {
+      if (event.target === elements.viewport) {
+        event.preventDefault();
+        handlePlayToggle();
+      }
+      break;
     }
+    default:
+      break;
+  }
+}
 
-    function nextStation() {
-      let nextIndex = currentStationIndex + playDirection;
-      if (nextIndex >= stations.length) nextIndex = 0;
-      if (nextIndex < 0) nextIndex = stations.length - 1;
-      playStation(nextIndex);
+function loadSettings() {
+  const storedVolume = localStorage.getItem(STORAGE_KEYS.volume);
+  const volume = storedVolume !== null ? Math.min(1, Math.max(0, Number(storedVolume))) : 0.7;
+  elements.volume.value = String(volume);
+  elements.announcementAudio.volume = volume;
+
+  const storedMute = localStorage.getItem(STORAGE_KEYS.muted);
+  if (storedMute !== null) {
+    state.muted = storedMute === 'true';
+    elements.announcementAudio.muted = state.muted;
+  }
+  syncMuteButton();
+
+  const storedRideMode = localStorage.getItem(STORAGE_KEYS.rideMode);
+  state.rideMode = storedRideMode === null ? true : storedRideMode === 'true';
+  syncRideModeButton();
+
+  const storedAmbient = localStorage.getItem(STORAGE_KEYS.ambient);
+  state.ambient = storedAmbient === 'true';
+  if (state.ambient) {
+    elements.ambientAudio.volume = 0.25;
+    elements.ambientAudio.play().catch(() => {
+      state.ambient = false;
+      localStorage.setItem(STORAGE_KEYS.ambient, 'false');
+    });
+  } else {
+    elements.ambientAudio.pause();
+  }
+  syncAmbientButton();
+}
+
+function initAudioEvents() {
+  elements.announcementAudio.addEventListener('play', () => {
+    state.playing = true;
+    updateTrackLabel('Playing');
+    syncPlayButtons();
+  });
+
+  elements.announcementAudio.addEventListener('pause', () => {
+    if (endedNaturally) {
+      endedNaturally = false;
+      return;
     }
+    state.playing = false;
+    updateTrackLabel('Paused');
+    syncPlayButtons();
+  });
 
-    // Play/pause button
-    playPauseBtn.addEventListener("click", () => {
-      if (audioElement.paused) {
-        audioElement.play();
-      } else {
-        audioElement.pause();
-      }
-    });
+  elements.announcementAudio.addEventListener('ended', () => {
+    endedNaturally = true;
+    state.playing = false;
+    updateTrackLabel('Complete');
+    syncPlayButtons();
+    if (state.rideMode) {
+      changeStation(1, { auto: true });
+    }
+  });
+}
 
-    // Volume sliders
-    document.getElementById("announcementVolumeSlider").addEventListener("input", e => {
-      announcementVolume = parseFloat(e.target.value);
-      if (currentAudioType === "announcement" && !announcementMuted) {
-        audioElement.volume = announcementVolume;
-      }
-    });
-    document.getElementById("stationVolumeSlider").addEventListener("input", e => {
-      stationVolume = parseFloat(e.target.value);
-      if (currentAudioType === "station" && !stationMuted) {
-        audioElement.volume = stationVolume;
-      }
-    });
+function initEventListeners() {
+  elements.playPause.addEventListener('click', handlePlayToggle);
+  elements.skip.addEventListener('click', () => changeStation(1));
+  elements.volume.addEventListener('input', (event) => {
+    const value = Number(event.target.value);
+    elements.announcementAudio.volume = value;
+    localStorage.setItem(STORAGE_KEYS.volume, String(value));
+    if (value > 0 && state.muted) {
+      state.muted = false;
+      elements.announcementAudio.muted = false;
+      localStorage.setItem(STORAGE_KEYS.muted, 'false');
+      syncMuteButton();
+    }
+  });
+  elements.mute.addEventListener('click', () => {
+    state.muted = !state.muted;
+    elements.announcementAudio.muted = state.muted;
+    localStorage.setItem(STORAGE_KEYS.muted, String(state.muted));
+    syncMuteButton();
+  });
 
-    // Mute toggles
-    document.getElementById("announcementVolumeIcon").addEventListener("click", () => {
-      announcementMuted = !announcementMuted;
-      const icon = document.getElementById("announcementVolumeIcon");
-      icon.textContent = announcementMuted ? "🔇" : "🔊";
-      if (currentAudioType === "announcement") {
-        audioElement.volume = announcementMuted ? 0 : announcementVolume;
-      }
-    });
-    document.getElementById("stationVolumeIcon").addEventListener("click", () => {
-      stationMuted = !stationMuted;
-      const icon = document.getElementById("stationVolumeIcon");
-      icon.textContent = stationMuted ? "🔇" : "🔊";
-      if (currentAudioType === "station") {
-        audioElement.volume = stationMuted ? 0 : stationVolume;
-      }
-    });
+  elements.rideMode.addEventListener('click', toggleRideMode);
+  elements.ambientToggle.addEventListener('click', toggleAmbient);
 
-    // Direction toggle
-    directionToggle.addEventListener("change", () => {
-      if (directionToggle.checked) {
-        playDirection = 1;
-        directionText.textContent = "Clockwise";
-      } else {
-        playDirection = -1;
-        directionText.textContent = "Counterclockwise";
-      }
-      updateArrowAnimation();
-    });
+  elements.mapToggle.addEventListener('click', () => toggleMap());
+  elements.closeMap.addEventListener('click', () => toggleMap(false));
+  if (elements.mobileMap) {
+    elements.mobileMap.addEventListener('click', () => toggleMap());
+  }
+  if (elements.mobilePlay) {
+    elements.mobilePlay.addEventListener('click', handlePlayToggle);
+  }
+  if (elements.mobileSkip) {
+    elements.mobileSkip.addEventListener('click', () => changeStation(1));
+  }
 
-    // On window load
-    window.onload = function() {
-      const savedLayout = localStorage.getItem("layout");
-      if (savedLayout === "modern") {
-        document.body.classList.add("modern-layout");
-        layoutToggle.textContent = "Classic Layout";
-        // Build grid layout
-        document.getElementById("arrowContainer").innerHTML = "";
-        const stationsContainer = document.getElementById("stations");
-        stations.forEach((st, i) => {
-          const div = document.createElement("div");
-          div.classList.add("station");
-          div.textContent = st.name;
-          div.dataset.index = i;
-          div.addEventListener("click", () => playStation(i));
-          stationsContainer.appendChild(div);
-        });
-      } else {
-        layoutToggle.textContent = "Switch Layout";
-        generateArrows();
-        updateArrowAnimation();
-        placeStations();
-      }
-    };
+  elements.searchInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleSearchJump();
+    }
+  });
+  elements.jumpButton.addEventListener('click', handleSearchJump);
+
+  elements.viewport.addEventListener('wheel', handleWheel, { passive: true });
+  elements.viewport.addEventListener('touchstart', handleTouchStart, { passive: true });
+  elements.viewport.addEventListener('touchend', handleTouchEnd, { passive: true });
+  elements.viewport.addEventListener('keydown', handleKeyNavigation);
+}
+
+function init() {
+  loadSettings();
+  syncPlayButtons();
+  buildSearchOptions();
+  buildMap();
+  initAudioEvents();
+  initEventListeners();
+  goToStation(state.index);
+  updateTrackLabel('Ready');
+}
+
+init();

--- a/Sites/yamanoteline/style.css
+++ b/Sites/yamanoteline/style.css
@@ -1,257 +1,541 @@
-/* Basic reset */
-html, body {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  font-family: Arial, sans-serif;
-  background-color: #fff;
+:root {
+  color-scheme: dark;
+  --bg-primary: #050b1e;
+  --bg-overlay: rgba(5, 11, 30, 0.65);
+  --text-primary: #f4f8ff;
+  --text-muted: rgba(244, 248, 255, 0.75);
+  --accent: #39c0ff;
+  --accent-soft: rgba(57, 192, 255, 0.25);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --panel-bg: rgba(12, 19, 43, 0.65);
+  --panel-blur: saturate(130%) blur(18px);
+  --transition-fast: 180ms ease;
+  --transition-medium: 320ms ease;
 }
 
-/* Dark mode styles */
-body.dark-mode {
-  background-color: #222;
-  color: #eee;
-}
-body.dark-mode .station {
-  border-color: #888;
-  background-color: #333;
-  color: #eee;
-}
-body.dark-mode .station:hover {
-  background-color: #444;
-}
-body.dark-mode .arrow {
-  color: #aaa;
-}
-body.dark-mode #audioPlayer {
-  background-color: #333;
-  box-shadow: 0 -2px 10px rgba(255,255,255,0.1);
-}
-body.dark-mode .volume-label,
-body.dark-mode .switch-control,
-body.dark-mode #skipText,
-body.dark-mode #directionText,
-body.dark-mode #darkModeText {
-  color: #ccc;
-}
-body.dark-mode .control-button {
-  color: #ccc;
-}
-body.dark-mode .control-button:hover {
-  color: #fff;
-}
-
-/* Circle wrapper for arrows and stations */
-#circleWrapper {
-  width: 700px;
-  height: 700px;
-  margin: 40px auto 0;
-  position: relative;
+* {
   box-sizing: border-box;
-  /* Remove background color to avoid gray box */
-  background-color: transparent;
 }
 
-/* Arrow container behind stations */
-#arrowContainer {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
+html,
+body {
+  height: 100%;
+  margin: 0;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+body {
   overflow: hidden;
-  animation-duration: 60s;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-  z-index: 1;
 }
 
-@keyframes spinClockwise {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
-}
-@keyframes spinCounterClockwise {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(-360deg); }
+.app {
+  min-height: 100vh;
+  position: relative;
 }
 
-/* Arrow styling */
-.arrow {
-  position: absolute;
-  font-size: 1em;
-  color: #91c73e;
-  opacity: 0.7;
+.top-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.25rem clamp(1rem, 4vw, 3rem);
+  background: linear-gradient(180deg, rgba(3, 5, 16, 0.92), rgba(3, 5, 16, 0.35));
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--glass-border);
 }
 
-/* Stations container (same size as #circleWrapper) */
-#stations {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
-  z-index: 2;
+.search-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 420px;
 }
 
-/* Station items placed on outer circle */
-.station {
-  position: absolute;
-  padding: 5px 10px;
-  border: 2px solid #91c73e;
-  border-radius: 8px;
-  background-color: #f9f9f9;
+.search-wrapper input[type="search"] {
+  flex: 1;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(8, 15, 36, 0.85);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.search-wrapper input[type="search"]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ghost-button {
+  appearance: none;
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  background: rgba(12, 20, 45, 0.55);
+  color: var(--text-primary);
+  font: inherit;
+  padding: 0.55rem 1.1rem;
   cursor: pointer;
-  font-size: 0.85em;
-  white-space: nowrap;
-  transform: translate(-50%, -50%);
-  transition: background-color 0.2s ease;
-  overflow: visible;
-}
-.station:hover {
-  background-color: #e0f0c0;
-}
-@keyframes pulse {
-  0%   { background-color: #A3D977; }
-  50%  { background-color: #7B9036; }
-  100% { background-color: #A3D977; }
-}
-.station.announcement-active {
-  animation: pulse 1.5s infinite;
-}
-.station.station-active {
-  background-color: #7B9036;
+  transition: background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
 }
 
-/* Audio bar pinned at bottom (100px tall) */
-#audioPlayer {
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(25, 38, 78, 0.75);
+  border-color: var(--accent);
+}
+
+.ghost-button:active {
+  transform: translateY(1px);
+}
+
+.station-viewport {
+  position: relative;
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(6rem, 14vh, 10rem) clamp(1.5rem, 8vw, 6rem);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.station-background {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: saturate(80%) blur(18px);
+  transform: scale(1.1);
+  transition: opacity var(--transition-medium), transform 2s ease;
+  opacity: 0.55;
+  z-index: -3;
+}
+
+.station-backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 30%, rgba(57, 192, 255, 0.22), transparent 55%),
+    linear-gradient(160deg, rgba(4, 9, 28, 0.95), rgba(3, 5, 16, 0.75));
+  z-index: -2;
+}
+
+.station-content {
+  position: relative;
+  max-width: min(900px, 100%);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.5rem, 4vw, 3rem);
+  border-radius: 32px;
+  background: var(--panel-bg);
+  backdrop-filter: var(--panel-blur);
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 30px 60px rgba(2, 6, 18, 0.45);
+}
+
+.station-titles {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.station-title {
+  margin: 0;
+  text-align: center;
+}
+
+.station-title--jp {
+  font-family: 'Noto Sans JP', sans-serif;
+  font-size: clamp(2.5rem, 8vw, 4rem);
+  font-weight: 700;
+  letter-spacing: 0.15em;
+}
+
+.station-title--en {
+  font-size: clamp(1.1rem, 4vw, 1.6rem);
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.station-info {
+  background: rgba(15, 24, 52, 0.55);
+  border-radius: 24px;
+  padding: clamp(1rem, 3vw, 1.75rem);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.station-info__heading {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: var(--text-muted);
+}
+
+.station-info__body {
+  margin: 0;
+  line-height: 1.7;
+  color: var(--text-primary);
+  font-size: clamp(0.95rem, 2.8vw, 1.05rem);
+}
+
+.transfer-lines {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.transfer-lines__heading {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.transfer-lines__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.transfer-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(13, 20, 38, 0.65);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+  cursor: default;
+}
+
+.transfer-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 50%;
+  font-weight: 600;
+  color: #0b0f1d;
+  background: var(--accent);
+}
+
+.transfer-lines__empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.station-preview {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(90%, 520px);
+  text-align: center;
+  color: rgba(244, 248, 255, 0.55);
+  pointer-events: none;
+  transition: opacity var(--transition-medium), transform var(--transition-medium);
+}
+
+.station-preview--previous {
+  top: clamp(1.5rem, 5vh, 3.5rem);
+}
+
+.station-preview--next {
+  bottom: clamp(1.5rem, 5vh, 3.5rem);
+}
+
+.station-preview__inner {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 13, 28, 0.45);
+  backdrop-filter: blur(16px);
+}
+
+.station-preview__direction {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+}
+
+.station-preview__jp {
+  display: block;
+  font-size: 1.2rem;
+  font-family: 'Noto Sans JP', sans-serif;
+}
+
+.station-preview__en {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+}
+
+.audio-panel {
+  position: absolute;
+  bottom: clamp(1.5rem, 6vh, 3.5rem);
+  right: clamp(1.5rem, 5vw, 4rem);
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-radius: 24px;
+  background: rgba(7, 12, 28, 0.75);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 18px 45px rgba(2, 8, 28, 0.5);
+}
+
+.audio-panel__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.control-button {
+  appearance: none;
+  border: none;
+  border-radius: 16px;
+  width: 3rem;
+  height: 3rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  background: linear-gradient(145deg, rgba(57, 192, 255, 0.9), rgba(22, 120, 255, 0.9));
+  color: #050b1e;
+  cursor: pointer;
+  box-shadow: 0 12px 25px rgba(10, 40, 90, 0.55);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.control-button:hover,
+.control-button:focus-visible {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 16px 30px rgba(10, 40, 90, 0.65);
+}
+
+.control-button:active {
+  transform: scale(0.96);
+}
+
+.audio-panel__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.track-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.volume-control {
+  display: inline-flex;
+  align-items: center;
+}
+
+.volume-control input[type="range"] {
+  width: 120px;
+}
+
+.mobile-dock {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  height: 100px;
-  background-color: #fff;
-  box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: 5px 20px;
-  box-sizing: border-box;
-  z-index: 10;
+  display: none;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: rgba(4, 8, 22, 0.94);
+  border-top: 1px solid var(--glass-border);
+  z-index: 25;
 }
 
-/* Left controls: volume sliders horizontally */
-.left-controls {
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  align-items: center;
-}
-.volume-control {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-.volume-label {
-  font-size: 0.85em;
-  color: #555;
-}
-.volume-icon {
-  font-size: 1.1em;
-  background: none;
+.dock-button {
+  flex: 1;
+  appearance: none;
   border: none;
-  cursor: pointer;
-  color: #91c73e;
-}
-.volume-icon:hover {
-  color: #7B9036;
-}
-#announcementVolumeSlider,
-#stationVolumeSlider {
-  width: 90px;
-}
-
-/* Center controls: station name + play/pause button (stacked) */
-.center-controls {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-#currentStation {
-  font-weight: bold;
-  font-size: 1.1em;
-  margin-bottom: 4px;
-}
-.control-button {
-  background: none;
-  border: none;
-  font-size: 2em;
-  cursor: pointer;
-  color: #91c73e;
-  padding: 5px;
-}
-.control-button:hover {
-  color: #7B9036;
+  border-radius: 14px;
+  padding: 0.65rem 1rem;
+  background: rgba(28, 46, 90, 0.65);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
-/* Right controls: toggles horizontally */
-.right-controls {
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  align-items: center;
-}
-.switch-control {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.85em;
-  color: #555;
-}
-#skipText, #directionText, #darkModeText {
-  min-width: 80px;
-  text-align: right;
-}
-
-/* Toggle switch styling */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 22px;
-}
-.switch input {
+.map-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background: rgba(2, 6, 18, 0.82);
+  backdrop-filter: blur(22px);
   opacity: 0;
-  width: 0;
-  height: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-medium);
+  z-index: 30;
 }
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background-color: #ccc;
-  transition: 0.4s;
-  border-radius: 22px;
+
+.map-overlay--active {
+  opacity: 1;
+  pointer-events: auto;
 }
-.slider:before {
+
+.map-overlay__inner {
+  position: relative;
+  width: min(90vw, 720px);
+  aspect-ratio: 1 / 1;
+  padding: 1.5rem;
+  border-radius: 32px;
+  background: rgba(7, 14, 32, 0.9);
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  display: grid;
+  gap: 1rem;
+}
+
+.map-overlay__title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.map-overlay__close {
   position: absolute;
-  content: "";
-  height: 16px;
-  width: 16px;
-  left: 3px;
-  bottom: 3px;
-  background-color: #fff;
-  transition: 0.4s;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
 }
-input:checked + .slider {
-  background-color: #91c73e;
+
+#loopMap {
+  width: 100%;
+  height: 100%;
 }
-input:focus + .slider {
-  box-shadow: 0 0 1px #91c73e;
+
+.loop-path {
+  fill: none;
+  stroke: rgba(57, 192, 255, 0.35);
+  stroke-width: 6;
+  stroke-dasharray: 6 14;
 }
-input:checked + .slider:before {
-  transform: translateX(18px);
+
+.map-node circle {
+  fill: rgba(12, 24, 60, 0.95);
+  stroke: rgba(57, 192, 255, 0.6);
+  stroke-width: 3;
+  transition: transform var(--transition-fast), fill var(--transition-fast);
 }
-.slider.round {
-  border-radius: 22px;
+
+.map-node text {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  fill: var(--text-muted);
 }
-.slider.round:before {
-  border-radius: 50%;
+
+.map-node:hover circle,
+.map-node.is-active circle {
+  fill: rgba(57, 192, 255, 0.9);
+  transform: scale(1.1);
+}
+
+.map-node.is-active text {
+  fill: var(--text-primary);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1024px) {
+  .top-bar {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .station-content {
+    padding: clamp(1.25rem, 4vw, 2rem);
+  }
+
+  .audio-panel {
+    right: clamp(1rem, 4vw, 2rem);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    overflow: auto;
+  }
+
+  .station-viewport {
+    padding: 8.5rem 1.25rem 8rem;
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .station-background {
+    position: fixed;
+  }
+
+  .audio-panel {
+    display: none;
+  }
+
+  .mobile-dock {
+    display: flex;
+  }
+
+  .station-preview {
+    display: none;
+  }
+
+  .top-bar {
+    position: sticky;
+  }
+
+  .station-content {
+    gap: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }


### PR DESCRIPTION
## Summary
- rework the station page markup into a full-screen layout with previews, immersive backgrounds, audio controls, search, and an interactive map overlay
- refresh the styling with glassmorphism panels, neon accents, responsive mobile controls, and a circular zoom-out map view
- refactor the station JavaScript to manage the 30-station dataset, ride-mode playback, gestures, jump search, and the interactive SVG loop

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a1c934948328999813d659c73af4