### PR TITLE
Revamp Yamanote station UI and interactions

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -9,20 +9,23 @@
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@500;700&display=swap"
+    rel="stylesheet">
 </head>
 <body>
   <div id="app" class="app">
     <header class="top-bar">
-      <button id="mapToggle" class="ghost-button" aria-expanded="false">Map</button>
-      <div class="search-wrapper">
-        <label class="sr-only" for="stationSearch">Search stations</label>
-        <input id="stationSearch" list="stationList" type="search" placeholder="Search stations…" autocomplete="off">
-        <datalist id="stationList"></datalist>
-        <button id="jumpButton" class="ghost-button">Go</button>
+      <div class="top-bar__group">
+        <button id="mapToggle" class="ghost-button" aria-expanded="false">Map</button>
+        <div class="search-wrapper">
+          <label class="sr-only" for="stationSearch">Search stations</label>
+          <input id="stationSearch" list="stationList" type="search" placeholder="Search stations…" autocomplete="off">
+          <datalist id="stationList"></datalist>
+          <button id="jumpButton" class="ghost-button">Go</button>
+        </div>
       </div>
       <div class="top-actions">
-
         <button id="rideModeButton" class="ghost-button" aria-pressed="false">Ride Mode</button>
         <button id="ambientToggle" class="ghost-button" aria-pressed="false">Ambient Off</button>
       </div>
@@ -49,33 +52,42 @@
         </section>
       </section>
 
-      <div class="audio-panel" role="region" aria-label="Station announcements">
-        <div class="audio-panel__primary">
-          <button id="playPause" class="control-button" aria-pressed="false">▶</button>
-          <button id="skipStation" class="control-button" aria-label="Skip to next station">⏭</button>
-          <div class="volume-control">
-            <label for="volumeSlider">Volume</label>
-            <input id="volumeSlider" type="range" min="0" max="1" step="0.01">
+      <div class="audio-pill" role="region" aria-label="Station announcements">
+        <div class="audio-pill__controls">
+          <button id="playPause" class="pill-button" aria-pressed="false" aria-label="Play or pause announcement">▶</button>
+          <button id="skipStation" class="pill-button" aria-label="Skip to next station">⏭</button>
+          <div class="audio-pill__volume" data-open="false">
+            <button id="volumeToggle" class="pill-button pill-button--ghost" aria-expanded="false" aria-controls="volumeSlider" aria-label="Adjust volume">🔊</button>
+            <div class="audio-pill__slider">
+              <label class="sr-only" for="volumeSlider">Volume</label>
+              <input id="volumeSlider" type="range" min="0" max="1" step="0.01">
+            </div>
           </div>
+          <button id="audioMapButton" class="pill-button pill-button--map" aria-expanded="false" aria-label="Open line map">
+            <span class="pill-button__icon" aria-hidden="true">
+              <svg viewBox="0 0 32 32" focusable="false" role="presentation">
+                <circle cx="16" cy="16" r="14" stroke-width="2"></circle>
+                <circle cx="16" cy="16" r="4" stroke-width="2"></circle>
+              </svg>
+            </span>
+            <span class="pill-button__label">Map</span>
+          </button>
         </div>
-        <div class="audio-panel__secondary">
+        <div class="audio-pill__meta">
           <span id="currentTrackLabel" class="track-label"></span>
           <button id="muteButton" class="ghost-button" aria-pressed="false">Mute</button>
         </div>
       </div>
-
-      <nav class="mobile-dock" aria-label="Mobile controls">
-        <button id="mobilePlay" class="dock-button" aria-pressed="false">▶</button>
-        <button id="mobileSkip" class="dock-button" aria-label="Skip to next">⏭</button>
-        <button id="mobileMap" class="dock-button" aria-expanded="false">Map</button>
-      </nav>
     </main>
 
     <aside id="mapOverlay" class="map-overlay" aria-hidden="true">
-      <div class="map-overlay__inner">
-        <button id="closeMap" class="ghost-button map-overlay__close" aria-label="Close map">×</button>
-        <h2>Yamanote Loop</h2>
-        <svg id="loopMap" viewBox="0 0 600 600" role="img" aria-label="Interactive map of the Yamanote Line"></svg>
+      <div class="map-overlay__scrim" data-close="true"></div>
+      <div class="map-overlay__panel" role="dialog" aria-labelledby="mapHeading">
+        <header class="map-overlay__header">
+          <h2 id="mapHeading">Yamanote Loop</h2>
+          <button id="closeMap" class="ghost-button map-overlay__close" aria-label="Close map">×</button>
+        </header>
+        <div class="map-overlay__line" id="mapLine" role="list"></div>
       </div>
     </aside>
   </div>

--- a/Sites/yamanoteline/style.css
+++ b/Sites/yamanoteline/style.css
@@ -1,50 +1,57 @@
 :root {
   color-scheme: dark;
-
-  --bg-dark: rgba(5, 15, 30, 0.75);
-  --glass: rgba(15, 25, 45, 0.75);
-  --accent: #3fc3ff;
-  --accent-strong: #1f91ff;
-  --text-primary: #f4f7fa;
-  --text-muted: rgba(244, 247, 250, 0.7);
-  --info-bg: rgba(20, 35, 60, 0.65);
-  --shadow-lg: 0 25px 60px rgba(0, 0, 0, 0.45);
+  --jr-green: #00bb85;
+  --jr-green-soft: rgba(0, 187, 133, 0.65);
+  --bg-deep: #04090f;
+  --bg-overlay: rgba(3, 10, 16, 0.55);
+  --glass: rgba(5, 18, 24, 0.65);
+  --glass-strong: rgba(8, 28, 34, 0.85);
+  --text-primary: #f4fbf7;
+  --text-muted: rgba(244, 251, 247, 0.65);
+  --shadow-xl: 0 28px 60px rgba(0, 0, 0, 0.45);
+  --shadow-soft: 0 20px 35px rgba(0, 0, 0, 0.35);
   --transition-fast: 200ms ease;
-
+  --transition-slow: 600ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 * {
   box-sizing: border-box;
 }
 
-
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: 'Poppins', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'Inter', 'Roboto', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   color: var(--text-primary);
-  background: #020812;
+  background: radial-gradient(circle at top, rgba(0, 187, 133, 0.08), transparent 65%), var(--bg-deep);
   overflow: hidden;
-}
-
-img {
-  max-width: 100%;
-  display: block;
 }
 
 button {
   font: inherit;
   color: inherit;
-  cursor: pointer;
   border: none;
   background: none;
+  cursor: pointer;
 }
 
 button:focus-visible,
 input:focus-visible,
-[role="button"]:focus-visible {
-  outline: 2px solid var(--accent);
+[role='button']:focus-visible {
+  outline: 2px solid var(--jr-green);
   outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app {
@@ -52,6 +59,7 @@ input:focus-visible,
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  isolation: isolate;
 }
 
 .top-bar {
@@ -60,12 +68,19 @@ input:focus-visible,
   left: 0;
   right: 0;
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 1rem 2rem;
-  z-index: 20;
+  align-items: center;
+  padding: 1rem 2.5rem;
+  gap: 1.25rem;
+  z-index: 30;
   backdrop-filter: blur(14px);
-  background: linear-gradient(180deg, rgba(2, 8, 18, 0.85) 0%, rgba(2, 8, 18, 0.35) 100%);
+  background: linear-gradient(180deg, rgba(2, 12, 14, 0.8) 0%, rgba(2, 12, 14, 0.25) 100%);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.top-bar__group {
+  display: flex;
+  align-items: center;
   gap: 1rem;
 }
 
@@ -73,19 +88,18 @@ input:focus-visible,
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.35rem 0.5rem;
+  padding: 0.4rem 0.8rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
-.search-wrapper input[type="search"] {
+.search-wrapper input[type='search'] {
   background: transparent;
   border: none;
   color: var(--text-primary);
-  padding: 0.35rem 0.75rem;
-  font-size: 0.95rem;
-  width: min(240px, 30vw);
+  padding: 0.35rem 0.5rem;
+  width: min(240px, 28vw);
 }
 
 .search-wrapper input::placeholder {
@@ -93,7 +107,7 @@ input:focus-visible,
 }
 
 .ghost-button {
-  padding: 0.4rem 1.1rem;
+  padding: 0.45rem 1.1rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   color: var(--text-primary);
@@ -101,9 +115,9 @@ input:focus-visible,
 }
 
 .ghost-button:hover,
-.ghost-button[aria-pressed="true"],
-.ghost-button[aria-expanded="true"] {
-  background: rgba(63, 195, 255, 0.25);
+.ghost-button[aria-pressed='true'],
+.ghost-button[aria-expanded='true'] {
+  background: rgba(0, 187, 133, 0.25);
 }
 
 .ghost-button:active {
@@ -120,7 +134,7 @@ input:focus-visible,
   flex: 1;
   display: grid;
   place-items: center;
-  padding: 4rem 3rem;
+  padding: 5.5rem 3rem 8rem;
   overflow: hidden;
 }
 
@@ -129,91 +143,125 @@ input:focus-visible,
   inset: 0;
   background-size: cover;
   background-position: center;
-  filter: saturate(0.6) brightness(0.6) blur(0px);
-  transition: opacity 600ms ease, transform 600ms ease;
+  filter: saturate(0.7) brightness(0.65) blur(3px);
   opacity: 0;
-  transform: scale(1.05);
+  transform: scale(1.08);
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
 }
 
 .station-background::after {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at center, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.65));
+  background: linear-gradient(180deg, rgba(1, 8, 12, 0.2), rgba(1, 6, 10, 0.85));
 }
 
 .station-background.is-active {
   opacity: 1;
-  transform: scale(1);
+}
+
+.app[data-motion='forward'] .station-background {
+  transform: scale(1.12) translateY(-30px);
+}
+
+.app[data-motion='backward'] .station-background {
+  transform: scale(1.12) translateY(30px);
 }
 
 .station-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(2, 8, 18, 0.25) 20%, rgba(2, 8, 18, 0.85) 85%);
   pointer-events: none;
+  background: radial-gradient(circle at center, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.65));
 }
 
 .station-preview {
   position: absolute;
   width: 100%;
   text-align: center;
-  font-size: 1.1rem;
-  letter-spacing: 0.15em;
+  font-size: 1rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.35);
   font-weight: 600;
   pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.35;
+  filter: blur(3px);
+  transition: transform var(--transition-slow), opacity var(--transition-slow);
 }
 
 .station-preview--previous {
-  top: 1.5rem;
+  top: 2.5rem;
 }
 
 .station-preview--next {
-  bottom: 2rem;
+  bottom: 2.8rem;
+}
+
+.app[data-motion='forward'] .station-preview--previous,
+.app[data-motion='forward'] .station-preview--next {
+  transform: translateY(-20px);
+  opacity: 0.2;
+}
+
+.app[data-motion='backward'] .station-preview--previous,
+.app[data-motion='backward'] .station-preview--next {
+  transform: translateY(20px);
+  opacity: 0.2;
 }
 
 .station-content {
   position: relative;
   z-index: 5;
-  max-width: min(680px, 90vw);
+  max-width: min(760px, 90vw);
   text-align: center;
   display: grid;
-  gap: 1.8rem;
+  gap: 2rem;
+  transition: transform var(--transition-slow);
+}
+
+.app[data-motion='forward'] .station-content {
+  transform: translateY(38px);
+}
+
+.app[data-motion='backward'] .station-content {
+  transform: translateY(-38px);
 }
 
 .station-name__jp {
-  font-family: 'Noto Sans JP', 'Poppins', sans-serif;
-  font-size: clamp(3.5rem, 6vw, 5.5rem);
+  font-family: 'Noto Sans JP', 'Inter', sans-serif;
+  font-size: clamp(3.2rem, 8vw, 5.8rem);
   font-weight: 700;
   letter-spacing: 0.18em;
   display: block;
+  text-shadow: 0 15px 35px rgba(0, 0, 0, 0.55);
 }
 
 .station-name__en {
   display: block;
-  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-size: clamp(1.75rem, 3.5vw, 2.8rem);
   font-weight: 600;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .station-info {
-  background: var(--info-bg);
-  padding: 1.5rem 2rem;
-  border-radius: 1.25rem;
-  box-shadow: var(--shadow-lg);
-  backdrop-filter: blur(18px);
+  margin: 0 auto;
+  padding: 1.8rem 2.25rem;
+  border-radius: 1.75rem;
+  background: linear-gradient(135deg, rgba(0, 187, 133, 0.08), rgba(8, 28, 34, 0.85));
+  backdrop-filter: blur(24px);
+  box-shadow: var(--shadow-xl);
 }
 
 .station-info__heading {
-  margin: 0 0 0.75rem;
-  font-size: 1.05rem;
-  letter-spacing: 0.2em;
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .station-info p {
@@ -224,22 +272,22 @@ input:focus-visible,
 
 .transfer-lines {
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .transfer-lines__heading {
   margin: 0;
   font-size: 0.95rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.2em;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .transfer-lines__list {
   display: flex;
-  justify-content: center;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  justify-content: center;
+  gap: 0.85rem;
 }
 
 .transfer-lines__empty {
@@ -252,8 +300,9 @@ input:focus-visible,
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
-  padding: 0.65rem 1rem;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
@@ -261,151 +310,196 @@ input:focus-visible,
 }
 
 .transfer-chip__icon {
-  width: 34px;
-  height: 34px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   display: grid;
   place-items: center;
   font-weight: 700;
-  font-size: 0.9rem;
-  color: #111;
+  font-size: 0.95rem;
+  color: #061014;
   background: #fff;
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.08);
 }
 
 .transfer-chip__name {
   font-size: 0.95rem;
   white-space: nowrap;
+  color: var(--text-muted);
+  transition: color var(--transition-fast);
 }
 
 .transfer-chip::after {
   content: attr(data-tooltip);
   position: absolute;
-  bottom: calc(100% + 0.5rem);
+  bottom: calc(100% + 0.6rem);
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(4, 10, 20, 0.85);
+  background: rgba(0, 0, 0, 0.8);
   color: #fff;
-  padding: 0.45rem 0.65rem;
+  padding: 0.45rem 0.75rem;
   border-radius: 0.6rem;
   font-size: 0.75rem;
   white-space: nowrap;
   opacity: 0;
   pointer-events: none;
-  transition: opacity var(--transition-fast);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.transfer-chip:hover,
+.transfer-chip:focus-visible {
+  transform: translateY(-4px);
+  background: rgba(0, 187, 133, 0.2);
+}
+
+.transfer-chip:hover .transfer-chip__name,
+.transfer-chip:focus-visible .transfer-chip__name {
+  color: var(--text-primary);
 }
 
 .transfer-chip:hover::after,
 .transfer-chip:focus-visible::after {
   opacity: 1;
+  transform: translateX(-50%) translateY(-4px);
 }
 
-.audio-panel {
-  position: absolute;
-  right: clamp(1rem, 5vw, 3rem);
-  bottom: clamp(2rem, 6vw, 4rem);
+.audio-pill {
+  position: fixed;
+  bottom: clamp(1.5rem, 5vw, 3rem);
+  left: 50%;
+  transform: translateX(-50%);
   display: grid;
-  gap: 0.75rem;
+  gap: 0.8rem;
   padding: 1rem 1.4rem;
-  border-radius: 1.25rem;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(16px);
-  box-shadow: var(--shadow-lg);
-  z-index: 10;
-  width: min(360px, 90vw);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(0, 187, 133, 0.32), rgba(5, 18, 24, 0.95));
+  box-shadow: var(--shadow-xl);
+  backdrop-filter: blur(24px);
+  z-index: 25;
+  width: min(520px, 92vw);
 }
 
-.audio-panel__primary,
-.audio-panel__secondary {
+.audio-pill__controls {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 0.9rem;
 }
 
-.control-button {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #021021;
-  font-size: 1.2rem;
+.pill-button {
+  width: 54px;
+  height: 54px;
+  border-radius: 999px;
+  background: rgba(0, 187, 133, 0.9);
+  color: #02110d;
   font-weight: 700;
-  box-shadow: 0 8px 18px rgba(31, 145, 255, 0.35);
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  font-size: 1.1rem;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 14px 28px rgba(0, 187, 133, 0.35);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
 }
 
-.control-button:hover {
+.pill-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 12px 25px rgba(31, 145, 255, 0.45);
+  box-shadow: 0 18px 32px rgba(0, 187, 133, 0.45);
 }
 
-.volume-control {
+.pill-button:active {
+  transform: scale(0.95);
+}
+
+.pill-button[aria-pressed='true'] {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.pill-button--ghost {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.pill-button--map {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0 1.1rem;
+  width: auto;
+  background: var(--jr-green);
+  color: #03120e;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pill-button__icon svg {
+  width: 22px;
+  height: 22px;
+  stroke: currentColor;
+  fill: none;
+}
+
+.pill-button__icon circle {
+  stroke: currentColor;
+}
+
+.audio-pill__volume {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  color: rgba(255, 255, 255, 0.65);
 }
 
-.volume-control input[type="range"] {
+.audio-pill__volume:hover .audio-pill__slider,
+.audio-pill__volume:focus-within .audio-pill__slider,
+.audio-pill__volume[data-open='true'] .audio-pill__slider {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: all;
+}
+
+.audio-pill__slider {
+  position: absolute;
+  bottom: calc(100% + 0.75rem);
+  left: 50%;
+  transform: translate(-50%, 10px);
+  padding: 0.6rem 0.85rem;
+  background: var(--glass-strong);
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-soft);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.audio-pill__slider input[type='range'] {
   width: 160px;
-  accent-color: var(--accent);
+  accent-color: var(--jr-green);
+}
+
+.audio-pill__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 0.5rem;
 }
 
 .track-label {
   font-size: 0.85rem;
-  color: var(--text-muted);
-  letter-spacing: 0.1em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-}
-
-.mobile-dock {
-  position: fixed;
-  bottom: 1.2rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.65);
-  border-radius: 999px;
-  display: none;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1.25rem;
-  backdrop-filter: blur(16px);
-  box-shadow: var(--shadow-lg);
-  z-index: 25;
-}
-
-.dock-button {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.12);
-  color: var(--text-primary);
-  font-size: 1.3rem;
-  font-weight: 600;
-  transition: background var(--transition-fast), transform var(--transition-fast);
-}
-
-.dock-button:hover,
-.dock-button:focus-visible,
-.dock-button[aria-pressed="true"],
-.dock-button[aria-expanded="true"] {
-  background: rgba(63, 195, 255, 0.35);
+  color: var(--text-muted);
 }
 
 .map-overlay {
   position: fixed;
   inset: 0;
   display: grid;
-  place-items: center;
-  background: rgba(2, 8, 18, 0.85);
-  backdrop-filter: blur(14px);
-  opacity: 0;
+  grid-template-columns: auto;
   pointer-events: none;
+  opacity: 0;
   transition: opacity 300ms ease;
-  z-index: 30;
+  z-index: 40;
 }
 
 .map-overlay.is-visible {
@@ -413,103 +507,163 @@ input:focus-visible,
   pointer-events: all;
 }
 
-.map-overlay__inner {
-  width: min(720px, 90vw);
-  aspect-ratio: 1 / 1;
-  background: rgba(2, 10, 22, 0.9);
-  border-radius: 2.5rem;
-  padding: 2rem;
-  box-shadow: var(--shadow-lg);
+.map-overlay__scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.map-overlay__panel {
   position: relative;
-  display: grid;
-  grid-template-rows: auto 1fr;
+  width: min(420px, 86vw);
+  height: 100vh;
+  background: linear-gradient(165deg, rgba(0, 187, 133, 0.95), rgba(3, 25, 20, 0.92));
+  box-shadow: 20px 0 45px rgba(0, 0, 0, 0.45);
+  padding: 2rem 2.2rem;
+  transform: translateX(-100%);
+  transition: transform 400ms cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.map-overlay.is-visible .map-overlay__panel {
+  transform: translateX(0);
+}
+
+.map-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.map-overlay__inner h2 {
+.map-overlay__header h2 {
   margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
   font-size: 1rem;
-  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(5, 25, 20, 0.85);
 }
 
-.map-overlay__close {
+.map-overlay__line {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.75rem;
+  background: rgba(2, 20, 16, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  padding: 2.5rem 0;
+}
+
+.map-overlay__line::before {
+  content: '';
   position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  font-size: 1.5rem;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
 }
 
-#loopMap {
+#mapLine {
+  position: relative;
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  padding: 3rem 0;
+  transition: transform 600ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-#loopMap .loop-group {
-  transform-box: fill-box;
-  transform-origin: 50% 50%;
-  transition: transform 600ms ease;
+.map-node {
+  position: relative;
+  display: grid;
+  place-items: center;
+  gap: 0.5rem;
+  text-align: center;
+  width: 100%;
+  background: none;
+  color: rgba(255, 255, 255, 0.55);
 }
 
-.loop-node {
-  cursor: pointer;
-  transition: transform var(--transition-fast), fill var(--transition-fast);
+.map-node::before {
+  content: '';
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.5);
+  background: rgba(0, 0, 0, 0.35);
+  transition: transform 300ms ease, border-color 300ms ease, box-shadow 300ms ease;
 }
 
-.loop-node circle {
-  fill: rgba(255, 255, 255, 0.7);
-  transform-box: fill-box;
-  transform-origin: center;
+.map-node__label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(12px);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 220ms ease, transform 220ms ease;
+  pointer-events: none;
 }
 
-.loop-node text {
-  fill: rgba(255, 255, 255, 0.7);
+.map-node__label span:first-child {
   font-size: 0.75rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
-.loop-node:hover circle {
-  fill: var(--accent);
+.map-node__label span:last-child {
+  font-family: 'Noto Sans JP', 'Inter', sans-serif;
+  font-size: 0.9rem;
 }
 
-.loop-node.active circle {
-  fill: var(--accent-strong);
-  animation: pulse 2s ease-in-out infinite;
+.map-node:hover::before,
+.map-node:focus-visible::before {
+  transform: scale(1.35);
+  border-color: #fff;
+  box-shadow: 0 0 18px rgba(255, 255, 255, 0.55);
 }
 
-@keyframes pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.35); }
+.map-node:hover .map-node__label,
+.map-node:focus-visible .map-node__label,
+.map-node.is-active .map-node__label {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+.map-node.is-active::before {
+  border-color: #fff;
+  box-shadow: 0 0 0 8px rgba(255, 255, 255, 0.08), 0 0 32px rgba(0, 0, 0, 0.55);
+  animation: halo 2.6s ease-in-out infinite;
+}
+
+@keyframes halo {
+  0%,
+  100% {
+    box-shadow: 0 0 0 8px rgba(255, 255, 255, 0.08), 0 0 32px rgba(0, 0, 0, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 14px rgba(255, 255, 255, 0.18), 0 0 48px rgba(0, 0, 0, 0.45);
+  }
 }
 
 @media (max-width: 1024px) {
   .top-bar {
-    padding: 0.75rem 1.25rem;
     flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
   }
 
-  .search-wrapper input[type="search"] {
-    width: min(220px, 50vw);
-  }
-
-  .audio-panel {
-    right: 50%;
-    transform: translateX(50%);
-    bottom: 7rem;
+  .search-wrapper input[type='search'] {
+    width: min(220px, 45vw);
   }
 }
 
@@ -519,50 +673,75 @@ input:focus-visible,
   }
 
   .station-viewport {
-    padding: 5rem 1.5rem 7rem;
-  }
-
-  .station-preview {
-    font-size: 0.85rem;
+    padding: 5rem 1.5rem 9.5rem;
   }
 
   .station-info {
-    padding: 1.25rem 1.5rem;
+    padding: 1.4rem 1.5rem;
   }
 
   .transfer-lines__list {
-    justify-content: center;
-    gap: 0.5rem;
+    gap: 0.6rem;
   }
 
   .transfer-chip {
-    padding: 0.55rem 0.85rem;
+    padding: 0.5rem 0.6rem;
   }
 
   .transfer-chip__icon {
-    width: 30px;
-    height: 30px;
+    width: 34px;
+    height: 34px;
   }
 
-  .audio-panel {
-    display: none;
+  .audio-pill {
+    width: calc(100vw - 2.5rem);
+    padding: 0.9rem 1.1rem;
   }
 
-  .mobile-dock {
-    display: flex;
+  .audio-pill__controls {
+    justify-content: space-between;
+  }
+
+  .pill-button {
+    width: 50px;
+    height: 50px;
+  }
+
+  .pill-button--map {
+    padding: 0 0.9rem;
+    font-size: 0.85rem;
+  }
+
+  .map-overlay__panel {
+    width: min(360px, 92vw);
   }
 }
 
 @media (max-width: 520px) {
   .top-bar {
     flex-direction: column;
+    align-items: stretch;
+  }
+
+  .top-bar__group {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .search-wrapper {
+    flex: 1;
   }
 
   .station-name__jp {
-    font-size: clamp(2.8rem, 10vw, 4rem);
+    font-size: clamp(2.6rem, 11vw, 4.1rem);
   }
 
   .station-name__en {
-    letter-spacing: 0.18em;
+    letter-spacing: 0.2em;
+  }
+
+  .audio-pill__meta {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the station view with JR-green glassmorphism panels, parallax transitions, and an immersive audio control pill
- rebuild the zoomed-out map as a sliding JR-green drawer with animated station nodes, pulsing halo, and keyboard support
- enhance interaction flow by defaulting ride mode on, syncing parallax scroll, and modernizing transfer tooltips and volume controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b40c5eac83288e87236893b73b3f