### PR TITLE
Add dark mode toggle and fix audio playback

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -28,6 +28,7 @@
       <div class="top-actions">
         <button id="rideModeButton" class="ghost-button" aria-pressed="true">Ride Mode On</button>
         <button id="ambientToggle" class="ghost-button" aria-pressed="false">Ambient Off</button>
+        <button id="darkModeToggle" class="ghost-button" aria-pressed="false">🌙 Dark Mode</button>
       </div>
     </header>
 
@@ -54,6 +55,7 @@
 
       <div class="audio-pill" role="region" aria-label="Station announcements">
         <div class="audio-pill__controls">
+          <button id="prevStation" class="pill-button" aria-label="Skip to previous station">⏮</button>
           <button id="playPause" class="pill-button" aria-pressed="false" aria-label="Play or pause announcement">▶</button>
           <button id="skipStation" class="pill-button" aria-label="Skip to next station">⏭</button>
           <div class="audio-pill__volume" data-open="false">
@@ -92,6 +94,7 @@
   </div>
 
   <audio id="announcementAudio" preload="auto" crossorigin="anonymous"></audio>
+  <audio id="jingleAudio" preload="auto" crossorigin="anonymous"></audio>
   <audio id="ambientAudio" preload="auto" loop crossorigin="anonymous" src="https://cdn.pixabay.com/audio/2022/03/15/audio_54c178aeb5.mp3"></audio>
 
   <script src="main.js" type="module"></script>

--- a/Sites/yamanoteline/style.css
+++ b/Sites/yamanoteline/style.css
@@ -6,12 +6,86 @@
   --bg-overlay: rgba(255, 255, 255, 0.7);
   --glass: rgba(255, 255, 255, 0.75);
   --glass-strong: rgba(255, 255, 255, 0.92);
+  --layer-medium: rgba(255, 255, 255, 0.85);
+  --layer-soft: rgba(255, 255, 255, 0.6);
   --text-primary: #1f3b37;
   --text-muted: rgba(31, 59, 55, 0.6);
+  --text-subtle: rgba(31, 59, 55, 0.35);
   --shadow-xl: 0 24px 48px rgba(31, 59, 55, 0.15);
   --shadow-soft: 0 18px 36px rgba(31, 59, 55, 0.12);
+  --shadow-elevated: 0 12px 24px rgba(31, 59, 55, 0.15);
+  --border-subtle: rgba(31, 59, 55, 0.08);
+  --control-ghost: rgba(47, 158, 68, 0.12);
+  --control-ghost-active: rgba(47, 158, 68, 0.25);
+  --control-ghost-outline: rgba(47, 158, 68, 0.25);
+  --surface-card-start: rgba(255, 255, 255, 0.92);
+  --surface-card-end: rgba(215, 233, 225, 0.85);
+  --surface-chip: rgba(255, 255, 255, 0.95);
+  --surface-chip-secondary: rgba(221, 238, 229, 0.92);
+  --surface-pill: rgba(255, 255, 255, 0.95);
+  --surface-pill-accent: rgba(221, 238, 229, 0.92);
+  --surface-floating: rgba(255, 255, 255, 0.95);
+  --surface-floating-strong: rgba(255, 255, 255, 0.9);
+  --overlay-gradient-start: rgba(255, 255, 255, 0.35);
+  --overlay-gradient-end: rgba(244, 248, 245, 0.85);
+  --map-line-color: rgba(47, 158, 68, 0.35);
+  --map-dot-bg: rgba(255, 255, 255, 0.9);
+  --map-label-bg: rgba(255, 255, 255, 0.95);
+  --scrim-color: rgba(31, 59, 55, 0.25);
+  --panel-shadow: 20px 0 45px rgba(31, 59, 55, 0.15);
+  --pill-button-bg: var(--jr-green);
+  --pill-button-text: #ffffff;
+  --pill-button-shadow: 0 14px 28px rgba(47, 158, 68, 0.25);
+  --pill-button-shadow-strong: 0 18px 32px rgba(47, 158, 68, 0.35);
+  --pill-button-ghost-bg: rgba(255, 255, 255, 0.6);
+  --pill-button-ghost-border: var(--border-subtle);
+  --audio-pill-shadow: 0 14px 28px rgba(47, 158, 68, 0.25);
+  --audio-pill-shadow-strong: 0 18px 32px rgba(47, 158, 68, 0.35);
   --transition-fast: 200ms ease;
   --transition-slow: 600ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+body.theme-dark {
+  color-scheme: dark;
+  background: radial-gradient(circle at top, rgba(47, 158, 68, 0.18), transparent 60%),
+    linear-gradient(180deg, #0f201b 0%, #020a07 100%);
+  --bg-deep: #020a07;
+  --bg-overlay: rgba(10, 23, 20, 0.65);
+  --glass: rgba(18, 30, 27, 0.82);
+  --glass-strong: rgba(18, 30, 27, 0.9);
+  --layer-medium: rgba(16, 26, 24, 0.85);
+  --layer-soft: rgba(16, 26, 24, 0.6);
+  --text-primary: #e6f2ed;
+  --text-muted: rgba(230, 242, 237, 0.65);
+  --text-subtle: rgba(230, 242, 237, 0.35);
+  --shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.5);
+  --shadow-soft: 0 18px 36px rgba(0, 0, 0, 0.4);
+  --shadow-elevated: 0 12px 24px rgba(0, 0, 0, 0.5);
+  --border-subtle: rgba(230, 242, 237, 0.12);
+  --control-ghost: rgba(47, 158, 68, 0.28);
+  --control-ghost-active: rgba(47, 158, 68, 0.5);
+  --control-ghost-outline: rgba(47, 158, 68, 0.5);
+  --surface-card-start: rgba(24, 40, 35, 0.95);
+  --surface-card-end: rgba(18, 32, 27, 0.9);
+  --surface-chip: rgba(26, 42, 36, 0.95);
+  --surface-chip-secondary: rgba(20, 34, 29, 0.92);
+  --surface-pill: rgba(24, 40, 35, 0.95);
+  --surface-pill-accent: rgba(18, 32, 28, 0.92);
+  --surface-floating: rgba(24, 40, 35, 0.95);
+  --surface-floating-strong: rgba(24, 40, 35, 0.9);
+  --overlay-gradient-start: rgba(15, 32, 27, 0.65);
+  --overlay-gradient-end: rgba(7, 20, 16, 0.88);
+  --map-line-color: rgba(108, 191, 133, 0.55);
+  --map-dot-bg: rgba(18, 30, 27, 0.95);
+  --map-label-bg: rgba(24, 40, 35, 0.95);
+  --scrim-color: rgba(0, 0, 0, 0.55);
+  --panel-shadow: 20px 0 45px rgba(0, 0, 0, 0.45);
+  --pill-button-shadow: 0 14px 28px rgba(0, 0, 0, 0.5);
+  --pill-button-shadow-strong: 0 18px 32px rgba(0, 0, 0, 0.6);
+  --pill-button-ghost-bg: rgba(24, 40, 35, 0.8);
+  --pill-button-ghost-border: rgba(230, 242, 237, 0.16);
+  --audio-pill-shadow: 0 14px 28px rgba(0, 0, 0, 0.5);
+  --audio-pill-shadow-strong: 0 18px 32px rgba(0, 0, 0, 0.6);
 }
 
 * {
@@ -75,8 +149,8 @@ input:focus-visible,
   gap: 1.25rem;
   z-index: 30;
   backdrop-filter: blur(14px);
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 12px 24px rgba(31, 59, 55, 0.15);
+  background: var(--layer-medium);
+  box-shadow: var(--shadow-elevated);
 }
 
 .top-bar__group {
@@ -91,8 +165,8 @@ input:focus-visible,
   gap: 0.5rem;
   padding: 0.4rem 0.8rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.75);
-  box-shadow: inset 0 0 0 1px rgba(31, 59, 55, 0.08);
+  background: var(--glass);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
 }
 
 .search-wrapper input[type='search'] {
@@ -110,7 +184,7 @@ input:focus-visible,
 .ghost-button {
   padding: 0.45rem 1.1rem;
   border-radius: 999px;
-  background: rgba(47, 158, 68, 0.12);
+  background: var(--control-ghost);
   color: var(--text-primary);
   transition: background var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
 }
@@ -118,8 +192,8 @@ input:focus-visible,
 .ghost-button:hover,
 .ghost-button[aria-pressed='true'],
 .ghost-button[aria-expanded='true'] {
-  background: rgba(47, 158, 68, 0.25);
-  box-shadow: 0 0 0 1px rgba(47, 158, 68, 0.25);
+  background: var(--control-ghost-active);
+  box-shadow: 0 0 0 1px var(--control-ghost-outline);
 }
 
 .ghost-button:active {
@@ -151,11 +225,15 @@ input:focus-visible,
   transition: opacity var(--transition-slow), transform var(--transition-slow);
 }
 
+body.theme-dark .station-background {
+  filter: saturate(0.8) brightness(0.55) blur(3px);
+}
+
 .station-background::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(244, 248, 245, 0.85));
+  background: linear-gradient(180deg, var(--overlay-gradient-start), var(--overlay-gradient-end));
 }
 
 .station-background.is-active {
@@ -174,7 +252,7 @@ input:focus-visible,
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.45), rgba(244, 248, 245, 0.85));
+  background: radial-gradient(circle at center, var(--bg-overlay), var(--bg-deep));
 }
 
 .station-preview {
@@ -184,7 +262,7 @@ input:focus-visible,
   font-size: 1rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(31, 59, 55, 0.35);
+  color: var(--text-subtle);
   font-weight: 600;
   pointer-events: none;
   opacity: 0.4;
@@ -236,8 +314,8 @@ input:focus-visible,
   font-weight: 700;
   letter-spacing: 0.18em;
   display: block;
-  color: rgba(12, 38, 32, 0.92);
-  text-shadow: 0 12px 24px rgba(31, 59, 55, 0.15);
+  color: var(--text-primary);
+  text-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
 }
 
 .station-name__en {
@@ -246,14 +324,14 @@ input:focus-visible,
   font-weight: 600;
   letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(31, 59, 55, 0.7);
+  color: var(--text-muted);
 }
 
 .station-info {
   margin: 0 auto;
   padding: 1.8rem 2.25rem;
   border-radius: 1.75rem;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(215, 233, 225, 0.85));
+  background: linear-gradient(135deg, var(--surface-card-start), var(--surface-card-end));
   backdrop-filter: blur(18px);
   box-shadow: var(--shadow-xl);
 }
@@ -263,7 +341,7 @@ input:focus-visible,
   font-size: 1rem;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(31, 59, 55, 0.65);
+  color: var(--text-muted);
 }
 
 .station-info p {
@@ -282,7 +360,7 @@ input:focus-visible,
   font-size: 0.95rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  color: rgba(31, 59, 55, 0.6);
+  color: var(--text-muted);
 }
 
 .transfer-lines__list {
@@ -306,8 +384,8 @@ input:focus-visible,
   gap: 0.75rem;
   padding: 0.55rem 0.75rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: inset 0 0 0 1px rgba(31, 59, 55, 0.08);
+  background: var(--surface-floating);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
   transition: transform var(--transition-fast), background var(--transition-fast);
 }
 
@@ -320,8 +398,8 @@ input:focus-visible,
   font-weight: 700;
   font-size: 0.95rem;
   color: #061014;
-  background: #fff;
-  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.08);
+  background: var(--surface-floating-strong);
+  box-shadow: inset 0 0 0 2px var(--border-subtle);
 }
 
 .transfer-chip__name {
@@ -337,7 +415,7 @@ input:focus-visible,
   bottom: calc(100% + 0.6rem);
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--surface-floating);
   color: var(--text-primary);
   padding: 0.45rem 0.75rem;
   border-radius: 0.6rem;
@@ -351,7 +429,7 @@ input:focus-visible,
 .transfer-chip:hover,
 .transfer-chip:focus-visible {
   transform: translateY(-4px);
-  background: rgba(47, 158, 68, 0.18);
+  background: var(--jr-green-soft);
 }
 
 .transfer-chip:hover .transfer-chip__name,
@@ -374,8 +452,8 @@ input:focus-visible,
   gap: 0.8rem;
   padding: 1rem 1.4rem;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(221, 238, 229, 0.92));
-  box-shadow: var(--shadow-xl);
+  background: linear-gradient(135deg, var(--surface-pill), var(--surface-pill-accent));
+  box-shadow: var(--audio-pill-shadow);
   backdrop-filter: blur(24px);
   z-index: 25;
   width: min(520px, 92vw);
@@ -392,19 +470,19 @@ input:focus-visible,
   width: 54px;
   height: 54px;
   border-radius: 999px;
-  background: var(--jr-green);
-  color: #ffffff;
+  background: var(--pill-button-bg);
+  color: var(--pill-button-text);
   font-weight: 700;
   font-size: 1.1rem;
   display: grid;
   place-items: center;
-  box-shadow: 0 14px 28px rgba(47, 158, 68, 0.25);
+  box-shadow: var(--pill-button-shadow);
   transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
 }
 
 .pill-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 32px rgba(47, 158, 68, 0.35);
+  box-shadow: var(--pill-button-shadow-strong);
 }
 
 .pill-button:active {
@@ -412,14 +490,14 @@ input:focus-visible,
 }
 
 .pill-button[aria-pressed='true'] {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--surface-floating);
   color: var(--text-primary);
 }
 
 .pill-button--ghost {
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--pill-button-ghost-bg);
   color: var(--text-primary);
-  box-shadow: inset 0 0 0 1px rgba(31, 59, 55, 0.08);
+  box-shadow: inset 0 0 0 1px var(--pill-button-ghost-border);
 }
 
 .pill-button--map {
@@ -428,8 +506,8 @@ input:focus-visible,
   gap: 0.45rem;
   padding: 0 1.1rem;
   width: auto;
-  background: var(--jr-green);
-  color: #ffffff;
+  background: var(--pill-button-bg);
+  color: var(--pill-button-text);
   font-size: 0.95rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -514,15 +592,15 @@ input:focus-visible,
 .map-overlay__scrim {
   position: absolute;
   inset: 0;
-  background: rgba(31, 59, 55, 0.25);
+  background: var(--scrim-color);
 }
 
 .map-overlay__panel {
   position: relative;
   width: min(420px, 86vw);
   height: 100vh;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(221, 238, 229, 0.92));
-  box-shadow: 20px 0 45px rgba(31, 59, 55, 0.15);
+  background: linear-gradient(180deg, var(--glass-strong), var(--surface-pill-accent));
+  box-shadow: var(--panel-shadow);
   padding: 2rem 2.2rem;
   transform: translateX(-100%);
   transition: transform 400ms cubic-bezier(0.16, 1, 0.3, 1);
@@ -547,7 +625,7 @@ input:focus-visible,
   font-size: 1rem;
   letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(31, 59, 55, 0.75);
+  color: var(--text-muted);
 }
 
 .map-overlay__line {
@@ -556,22 +634,15 @@ input:focus-visible,
   overflow-y: auto;
   border-radius: 1.75rem;
   background: var(--glass);
-  box-shadow: inset 0 0 0 1px rgba(31, 59, 55, 0.08);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
   padding: 2.5rem 0.5rem;
   scroll-behavior: smooth;
   overflow-x: hidden;
+  scrollbar-width: none;
 }
 
-.map-overlay__line::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 6px;
-  border-radius: 999px;
-  background: rgba(47, 158, 68, 0.35);
+.map-overlay__line::-webkit-scrollbar {
+  display: none;
 }
 
 #mapLine {
@@ -585,15 +656,28 @@ input:focus-visible,
   padding: 3rem 0;
 }
 
+#mapLine::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6px;
+  border-radius: 999px;
+  background: var(--map-line-color);
+}
+
 .map-node {
   position: relative;
+  z-index: 1;
   display: grid;
   place-items: center;
   gap: 0.5rem;
   text-align: center;
   width: 100%;
   background: none;
-  color: rgba(31, 59, 55, 0.65);
+  color: var(--text-muted);
 }
 
 .map-node::before {
@@ -601,8 +685,8 @@ input:focus-visible,
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  border: 4px solid rgba(47, 158, 68, 0.35);
-  background: rgba(255, 255, 255, 0.9);
+  border: 4px solid var(--map-line-color);
+  background: var(--map-dot-bg);
   transition: transform 300ms ease, border-color 300ms ease, box-shadow 300ms ease;
 }
 
@@ -612,8 +696,8 @@ input:focus-visible,
   gap: 0.15rem;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 12px 24px rgba(31, 59, 55, 0.12);
+  background: var(--map-label-bg);
+  box-shadow: var(--shadow-elevated);
   color: var(--text-primary);
   opacity: 1;
   transform: none;
@@ -624,7 +708,7 @@ input:focus-visible,
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(31, 59, 55, 0.6);
+  color: var(--text-muted);
 }
 
 .map-node__label span:last-child {


### PR DESCRIPTION
## Summary
- add a dark mode toggle with theme variables and persisted preference
- ensure jingles play after announcements and add a previous-station control
- polish the map overlay by hiding its scrollbar and extending the loop connector

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4bff5905c8328b6f8ead778dbe96c