### PR TITLE
Refine direction indicator, logos, and volume control

### DIFF
--- a/Sites/yamanoteline/index.html
+++ b/Sites/yamanoteline/index.html
@@ -69,12 +69,15 @@
 
       <div class="station-direction" aria-hidden="true">
         <div class="station-direction__rail">
-          <span class="station-direction__shuttle direction-indicator" aria-hidden="true"></span>
           <div class="station-direction__item station-direction__item--prev">
             <div class="station-direction__text">
               <span class="station-direction__label">From</span>
               <span id="directionPrevName" class="station-direction__name"></span>
             </div>
+          </div>
+          <div class="station-direction__indicator" aria-hidden="true">
+            <span class="station-direction__line"></span>
+            <span class="station-direction__shuttle" aria-hidden="true"></span>
           </div>
           <div class="station-direction__item station-direction__item--next">
             <div class="station-direction__text">

--- a/Sites/yamanoteline/main.js
+++ b/Sites/yamanoteline/main.js
@@ -410,6 +410,56 @@ const lineCatalog = {
   }
 };
 
+const lineLogos = {
+  'jr-chuo-rapid': 'https://upload.wikimedia.org/wikipedia/commons/7/79/JR_JC_line_symbol.svg',
+  'jr-keihin-tohoku': 'https://upload.wikimedia.org/wikipedia/commons/1/16/JR_JK_line_symbol.svg',
+  'jr-tokaido': 'https://upload.wikimedia.org/wikipedia/commons/9/92/JR_JT_line_symbol.svg',
+  'jr-utsunomiya': 'https://upload.wikimedia.org/wikipedia/commons/f/fc/JR_JU_line_symbol.svg',
+  'jr-takasaki': 'https://upload.wikimedia.org/wikipedia/commons/f/fc/JR_JU_line_symbol.svg',
+  'jr-joban-rapid': 'https://upload.wikimedia.org/wikipedia/commons/7/7c/JR_JJ_line_symbol.svg',
+  'jr-keiyo': 'https://upload.wikimedia.org/wikipedia/commons/c/c3/JR_JE_line_symbol.svg',
+  'jr-yokosuka-sobu': 'https://upload.wikimedia.org/wikipedia/commons/1/1b/JR_JO_line_symbol.svg',
+  'jr-chuo-sobu': 'https://upload.wikimedia.org/wikipedia/commons/0/03/JR_JB_line_symbol.svg',
+  'jr-saikyo': 'https://upload.wikimedia.org/wikipedia/commons/1/1c/JR_JA_line_symbol.svg',
+  'jr-shonan-shinjuku': 'https://upload.wikimedia.org/wikipedia/commons/0/04/JR_JS_line_symbol.svg',
+  'tokyo-metro-marunouchi': 'https://upload.wikimedia.org/wikipedia/commons/c/ca/Logo_of_Tokyo_Metro_Marunouchi_Line.svg',
+  'tokyo-metro-ginza': 'https://upload.wikimedia.org/wikipedia/commons/7/73/Logo_of_Tokyo_Metro_Ginza_Line.svg',
+  'tokyo-metro-hibiya': 'https://upload.wikimedia.org/wikipedia/commons/a/ab/Logo_of_Tokyo_Metro_Hibiya_Line.svg',
+  'tokyo-metro-tozai': 'https://upload.wikimedia.org/wikipedia/commons/d/db/Logo_of_Tokyo_Metro_T%C5%8Dzai_Line.svg',
+  'tokyo-metro-yurakucho': 'https://upload.wikimedia.org/wikipedia/commons/d/dd/Logo_of_Tokyo_Metro_Y%C5%ABrakuch%C5%8D_Line.svg',
+  'tokyo-metro-chiyoda': 'https://upload.wikimedia.org/wikipedia/commons/2/24/Logo_of_Tokyo_Metro_Chiyoda_Line.svg',
+  'tokyo-metro-namboku': 'https://upload.wikimedia.org/wikipedia/commons/a/a0/Logo_of_Tokyo_Metro_Namboku_Line.svg',
+  'tokyo-metro-fukutoshin': 'https://upload.wikimedia.org/wikipedia/commons/a/a3/Logo_of_Tokyo_Metro_Fukutoshin_Line.svg',
+  'tokyo-metro-hanzomon': 'https://upload.wikimedia.org/wikipedia/commons/d/d1/Logo_of_Tokyo_Metro_Hanz%C5%8Dmon_Line.svg',
+  'toei-asakusa': 'https://upload.wikimedia.org/wikipedia/commons/3/3c/Toei_Asakusa_line_symbol.svg',
+  'toei-mita': 'https://upload.wikimedia.org/wikipedia/commons/c/c1/Toei_Mita_line_symbol.svg',
+  'toei-oedo': 'https://upload.wikimedia.org/wikipedia/commons/0/08/Toei_Oedo_line_symbol.svg',
+  'toei-shinjuku': 'https://upload.wikimedia.org/wikipedia/commons/a/aa/Toei_Shinjuku_line_symbol.svg',
+  'keio-line': 'https://upload.wikimedia.org/wikipedia/commons/6/6f/Number_prefix_Keio-line.svg',
+  'keio-inokashira': 'https://upload.wikimedia.org/wikipedia/commons/a/ad/Number_prefix_Keio-Inokashira-line.svg',
+  'odakyu-odawara': 'https://upload.wikimedia.org/wikipedia/commons/4/4d/Odakyu_odawara.svg',
+  'tobu-tojo': 'https://upload.wikimedia.org/wikipedia/commons/7/76/Tobu_Tojo_Line_%28TJ%29_symbol.svg',
+  'tokyu-den-en-toshi': 'https://upload.wikimedia.org/wikipedia/commons/8/80/Tokyu_DT_line_symbol.svg',
+  'tokyu-toyoko': 'https://upload.wikimedia.org/wikipedia/commons/b/b0/Tokyu_TY_line_symbol.svg',
+  'tokyu-ikegami': 'https://upload.wikimedia.org/wikipedia/commons/1/17/Tokyu_IK_line_symbol.svg',
+  'tokyu-meguro': 'https://upload.wikimedia.org/wikipedia/commons/f/f0/Tokyu_MG_line_symbol.svg',
+  'tokyo-sakura-tram': 'https://upload.wikimedia.org/wikipedia/commons/6/66/Tokyo_Sakura_Tram_symbol.svg',
+  'nippori-toneri': 'https://upload.wikimedia.org/wikipedia/commons/9/9e/Nippori-Toneri_Liner_symbol.svg',
+  'tsukuba-express': 'https://upload.wikimedia.org/wikipedia/commons/2/2f/Tsukuba_Express_symbol.svg',
+  'keisei-main': 'https://upload.wikimedia.org/wikipedia/commons/b/bc/Number_prefix_Keisei.svg',
+  'keisei-skyliner': 'https://upload.wikimedia.org/wikipedia/commons/4/40/Number_prefix_SkyAccess.svg',
+  'tokyo-monorail': 'https://upload.wikimedia.org/wikipedia/commons/0/07/Tokyo_Monorail_Line_symbol.svg',
+  'yurikamome': 'https://upload.wikimedia.org/wikipedia/commons/1/1e/Yurikamome_line_symbol.svg',
+  'rinkai-line': 'https://upload.wikimedia.org/wikipedia/commons/e/e8/Rinkai_Line_symbol.svg',
+  'keikyu-main': 'https://upload.wikimedia.org/wikipedia/commons/e/e1/Number_prefix_Keiky%C5%AB.svg'
+};
+
+Object.entries(lineLogos).forEach(([id, logoUrl]) => {
+  if (lineCatalog[id]) {
+    lineCatalog[id].logo = logoUrl;
+  }
+});
+
 const stations = [
   {
     id: 'tokyo',
@@ -916,6 +966,17 @@ function setBackground(url) {
 }
 
 function renderLineIcon(line) {
+  if (line.logo) {
+    const img = document.createElement('img');
+    img.src = line.logo;
+    img.alt = '';
+    img.loading = 'lazy';
+    img.decoding = 'async';
+    img.className = 'transfer-chip__logo';
+    img.setAttribute('aria-hidden', 'true');
+    return img;
+  }
+
   const svgNS = 'http://www.w3.org/2000/svg';
   if (line.iconType === 'shinkansen') {
     const svg = document.createElementNS(svgNS, 'svg');
@@ -1252,7 +1313,8 @@ function updateVolumeSliderUI() {
   volumeSlider.value = String(sliderValue);
   volumeSlider.setAttribute('aria-valuenow', String(sliderValue));
   volumeSlider.setAttribute('aria-valuetext', `${sliderValue}%`);
-  volumeSlider.style.setProperty('--volume-fill', `${sliderValue}%`);
+  const clamped = Math.max(0, Math.min(1, masterVolume));
+  volumeSlider.style.setProperty('--volume-fill', clamped.toString());
 }
 
 function setMasterVolume(volume, options = {}) {
@@ -1700,12 +1762,22 @@ function bindEvents() {
   });
   searchGoButton.addEventListener('click', jumpToSearch);
   darkModeToggle?.addEventListener('click', () => setDarkMode(!darkMode));
-  volumeSlider?.addEventListener('input', (event) => {
-    const value = Number.parseInt(event.target.value, 10);
-    if (!Number.isNaN(value)) {
-      setMasterVolume(value / 100);
-    }
-  });
+  if (volumeSlider) {
+    volumeSlider.setAttribute('aria-valuemin', '0');
+    volumeSlider.setAttribute('aria-valuemax', '100');
+    const handleVolumeInput = (event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLInputElement)) {
+        return;
+      }
+      const value = Number.parseFloat(target.value);
+      if (!Number.isNaN(value)) {
+        setMasterVolume(value / 100);
+      }
+    };
+    volumeSlider.addEventListener('input', handleVolumeInput);
+    volumeSlider.addEventListener('change', handleVolumeInput);
+  }
   if (jingleAudio) {
     jingleAudio.addEventListener('ended', handleJingleEnd);
     jingleAudio.addEventListener('pause', handleJinglePause);

--- a/Sites/yamanoteline/style.css
+++ b/Sites/yamanoteline/style.css
@@ -230,12 +230,12 @@ input:focus-visible,
   width: clamp(120px, 12vw, 160px);
   height: 0.35rem;
   border-radius: 999px;
-  --volume-fill: 80%;
+  --volume-fill: 0.8;
   background: linear-gradient(
       90deg,
       rgba(47, 158, 68, 0.85) 0%,
-      rgba(47, 158, 68, 0.85) var(--volume-fill),
-      rgba(47, 158, 68, 0.25) var(--volume-fill),
+      rgba(47, 158, 68, 0.85) calc(var(--volume-fill) * 100%),
+      rgba(47, 158, 68, 0.25) calc(var(--volume-fill) * 100%),
       rgba(47, 158, 68, 0.25) 100%
     );
   outline: none;
@@ -379,113 +379,106 @@ body.theme-dark .station-background {
 .station-direction__rail {
   position: relative;
   display: grid;
-  gap: 1.35rem;
+  grid-template-columns: minmax(0, 1fr) minmax(1.4rem, 1.8rem);
+  column-gap: 1.25rem;
+  row-gap: 1.35rem;
+  align-items: center;
 }
 
 .station-direction__item {
+  grid-column: 1;
   display: flex;
   justify-content: flex-end;
   align-items: center;
 }
 
+.station-direction__indicator {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  min-width: 1.4rem;
+  min-height: calc(var(--direction-travel, 0px) + 3rem);
+  pointer-events: none;
+}
+
+.station-direction__line {
+  position: relative;
+  width: 0.28rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(47, 158, 68, 0.35), rgba(47, 158, 68, 0.15));
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.station-direction__line::before {
+  content: '';
+  position: absolute;
+  inset: -120% 0;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.9) 35%,
+    rgba(47, 158, 68, 0.9) 55%,
+    rgba(255, 255, 255, 0.85) 75%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  background-size: 100% 200%;
+  animation: directionFlow 1.4s linear infinite;
+}
+
+.station-direction__line::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 18%, rgba(255, 255, 255, 0.45), transparent 70%);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+}
+
 .station-direction__shuttle {
   position: absolute;
   top: 0;
-  right: calc(100% + 0.65rem);
-  width: 2.35rem;
-  height: 2.35rem;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  transform: translateY(0);
-}
-
-.direction-indicator {
-  position: relative;
-  width: 2.35rem;
-  height: 2.35rem;
-  border-radius: 50%;
-  background: linear-gradient(135deg, rgba(47, 158, 68, 0.4), rgba(47, 158, 68, 0.75));
-  box-shadow: 0 12px 24px rgba(31, 59, 55, 0.22);
-  overflow: hidden;
-}
-
-.direction-indicator::after {
-  content: '';
-  position: absolute;
-  inset: 50% auto auto 50%;
-  width: 65%;
-  height: 0.18rem;
-  border-radius: 999px;
-  transform: translate(-50%, -50%);
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.2));
-  background-size: 200% 100%;
-  animation: indicatorTrack 1.4s linear infinite;
-  opacity: 0.85;
-}
-
-.direction-indicator::before {
-  content: '';
-  position: absolute;
-  top: 50%;
   left: 50%;
-  width: 0.75rem;
-  height: 0.75rem;
-  border-top: 0.18rem solid #fff;
-  border-right: 0.18rem solid #fff;
-  transform: translate(-70%, -50%) rotate(45deg);
-  border-radius: 0.2rem;
-  filter: drop-shadow(0 3px 4px rgba(0, 0, 0, 0.2));
-  animation: indicatorForward 1.4s ease-in-out infinite;
+  width: 1.4rem;
+  height: 1.4rem;
+  transform: translate(-50%, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.direction-indicator--reverse {
-  transform: scaleX(-1);
+.station-direction__shuttle::before {
+  content: '';
+  width: 0.7rem;
+  height: 0.95rem;
+  background: linear-gradient(180deg, #ffffff 0%, rgba(255, 255, 255, 0.65) 100%);
+  clip-path: polygon(50% 100%, 0 44%, 30% 44%, 30% 0, 70% 0, 70% 44%, 100% 44%);
+  filter: drop-shadow(0 4px 6px rgba(31, 59, 55, 0.3));
+  transition: transform var(--transition-fast);
 }
 
-.direction-indicator--reverse::before {
-  animation-name: indicatorReverse;
+@keyframes directionFlow {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
+  }
 }
 
-.direction-indicator--reverse::after {
+.app[data-motion='forward'] .station-direction__shuttle::before {
+  transform: rotate(0deg);
+}
+
+.app[data-motion='backward'] .station-direction__line::before {
   animation-direction: reverse;
 }
 
-@keyframes indicatorTrack {
-  0% {
-    background-position: 0 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
-}
-
-@keyframes indicatorForward {
-  0% {
-    transform: translate(-110%, -50%) rotate(45deg);
-    opacity: 0;
-  }
-  45% {
-    opacity: 1;
-  }
-  100% {
-    transform: translate(10%, -50%) rotate(45deg);
-    opacity: 0;
-  }
-}
-
-@keyframes indicatorReverse {
-  0% {
-    transform: translate(-10%, -50%) rotate(45deg);
-    opacity: 0;
-  }
-  45% {
-    opacity: 1;
-  }
-  100% {
-    transform: translate(-130%, -50%) rotate(45deg);
-    opacity: 0;
-  }
+.app[data-motion='backward'] .station-direction__shuttle::before {
+  transform: rotate(180deg);
 }
 
 .station-direction__text {
@@ -607,11 +600,16 @@ body.theme-dark .station-background {
 .transfer-chip__icon {
   width: 3.1rem;
   height: 3.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.transfer-chip__icon svg {
+.transfer-chip__icon svg,
+.transfer-chip__icon img {
   width: 100%;
   height: 100%;
+  object-fit: contain;
 }
 
 .transfer-chip__tooltip {


### PR DESCRIPTION
## Summary
- replace the station direction callout with a vertical right-hand indicator that includes a pulsing travel line and animated arrow
- attach official transfer line logos to each network entry and render them inside chips while keeping shinkansen glyphs
- fix the volume slider so its fill and audio gain respond correctly to user interaction on both input and change events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4e19f309c83288a65dfa2cff20734