### PR TITLE
Add reset view control and loading state to JP map

### DIFF
--- a/Sites/jp-train-station/index.html
+++ b/Sites/jp-train-station/index.html
@@ -40,6 +40,15 @@
         <button class="btn" type="submit" aria-label="Search stations">Search</button>
       </form>
       <p id="searchHint" class="search-hint">Zoom and tap markers or search by name to explore stations.</p>
+      <button
+        id="resetView"
+        class="btn btn-secondary"
+        type="button"
+        disabled
+        aria-label="Reset the map view to show all stations"
+      >
+        Reset view
+      </button>
     </div>
     <section id="stationPanel" class="station-panel" aria-live="polite">
       <header class="panel-header">

--- a/Sites/jp-train-station/styles.css
+++ b/Sites/jp-train-station/styles.css
@@ -132,6 +132,25 @@ body {
   box-shadow: 0 10px 24px rgba(59, 130, 246, 0.35);
 }
 
+.btn-secondary {
+  background: rgba(59, 130, 246, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: none;
+  color: var(--text-strong);
+  padding-inline: 1rem;
+}
+
+.btn-secondary:not(:disabled):hover,
+.btn-secondary:not(:disabled):focus-visible {
+  transform: none;
+  background: rgba(59, 130, 246, 0.3);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.btn-secondary:disabled {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
 .btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- add a Reset view control to return the map to the nationwide bounds after panning
- improve station loading workflow by clearing stale markers, repopulating suggestions, and surfacing progress messages
- style a secondary button variant that fits the glassmorphism overlay

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df8aae2c5483288884ceb818996965