### PR TITLE
Fix Leaflet asset integrity hashes

### DIFF
--- a/Sites/jp-train-station/index.html
+++ b/Sites/jp-train-station/index.html
@@ -7,7 +7,7 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha512-sA+4Z1W96gQ87XZy4V/mQJu1nvLKYj1WFJsbgx5caX5/C/POb44IVdQydb9h9NP7VDaRaoTyIhiikmTDdSqaLQ=="
+      integrity="sha512-Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
       crossorigin=""
     >
     <link
@@ -84,7 +84,7 @@
     </section>
     <script
       src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha512-pIqFQJQGsi9h9uKXuX4nHCqB6Sm+GO6zkRgZNpmj12E7YQDdyCjTiMQuu2cEGoVYLRNvKcJsteUmsA2xZr3G3g=="
+      integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
       crossorigin=""
       defer
     ></script>


### PR DESCRIPTION
## Summary
- update the Leaflet CSS and JS SRI hashes to the official values to restore asset loading

## Testing
- Manual: Loaded http://127.0.0.1:8000/index.html to verify the map and station clusters render


------
https://chatgpt.com/codex/tasks/task_e_68e5c0e91bc4832890fe0a29a34ef4ac