### PR TITLE
Add operator and line filters for JP train stations

### DIFF
--- a/Sites/jp-train-station/index.html
+++ b/Sites/jp-train-station/index.html
@@ -24,7 +24,21 @@
     <a class="skip-link" href="#stationPanel">Skip to station details</a>
     <div id="map" class="map" role="application" aria-label="Interactive map of Japan"></div>
     <div class="map-overlay top" role="search">
-      <div class="brand">JP Train Station</div>
+      <div class="overlay-header">
+        <div>
+          <div class="brand">JP Train Station</div>
+          <p class="overlay-subtitle">Melodies, operators, and lines across Japan</p>
+        </div>
+        <button
+          id="resetView"
+          class="btn btn-secondary"
+          type="button"
+          disabled
+          aria-label="Reset the map view to the current selection"
+        >
+          Reset view
+        </button>
+      </div>
       <form id="stationSearch" class="search" autocomplete="off">
         <label class="sr-only" for="stationQuery">Search for a station</label>
         <input
@@ -34,35 +48,99 @@
           placeholder="Search for a station"
           inputmode="search"
           list="stationSuggestions"
-          aria-describedby="searchHint"
+          aria-describedby="searchHint filterSummary"
         >
         <datalist id="stationSuggestions"></datalist>
         <button class="btn" type="submit" aria-label="Search stations">Search</button>
       </form>
-      <p id="searchHint" class="search-hint">Zoom and tap markers or search by name to explore stations.</p>
-      <button
-        id="resetView"
-        class="btn btn-secondary"
-        type="button"
-        disabled
-        aria-label="Reset the map view to show all stations"
-      >
-        Reset view
-      </button>
+      <section class="filter-panel" aria-label="Station filters">
+        <header class="filter-header">
+          <h2>Filter by operator and line</h2>
+          <p id="filtersHelp" class="filter-helper">
+            Combine the filters below with the station search to focus on specific rail operators or train lines.
+          </p>
+        </header>
+        <div class="filter-groups">
+          <div class="filter-group">
+            <label for="operatorSearch">Operators</label>
+            <input
+              id="operatorSearch"
+              class="filter-search"
+              type="search"
+              placeholder="Search operators"
+              aria-describedby="operatorHelper"
+              inputmode="search"
+            >
+            <p id="operatorHelper" class="filter-helper-text">
+              Tap or hold Ctrl/Cmd while selecting to choose multiple operators.
+            </p>
+            <select
+              id="operatorFilter"
+              class="filter-select"
+              name="operatorFilter"
+              multiple
+              size="6"
+              aria-describedby="operatorHelper filtersHelp filterSummary"
+            ></select>
+          </div>
+          <div class="filter-group">
+            <label for="lineSearch">Lines</label>
+            <input
+              id="lineSearch"
+              class="filter-search"
+              type="search"
+              placeholder="Search lines"
+              aria-describedby="lineHelper"
+              inputmode="search"
+            >
+            <p id="lineHelper" class="filter-helper-text">
+              Select one or more lines to instantly update the map markers.
+            </p>
+            <select
+              id="lineFilter"
+              class="filter-select"
+              name="lineFilter"
+              multiple
+              size="6"
+              aria-describedby="lineHelper filtersHelp filterSummary"
+            ></select>
+          </div>
+        </div>
+        <div class="filter-actions">
+          <p id="filterSummary" class="filter-summary" aria-live="polite"></p>
+          <div class="filter-buttons">
+            <button id="clearFilters" class="btn btn-secondary" type="button">Clear filters</button>
+          </div>
+        </div>
+      </section>
+      <p id="searchHint" class="search-hint">
+        Search by station name or combine operator and line filters to explore melodies with precision.
+      </p>
     </div>
     <section id="stationPanel" class="station-panel" aria-live="polite">
       <header class="panel-header">
         <h1 id="stationName">Explore Japan's railways</h1>
         <p id="stationSummary">Use the map or search above to find a station and listen to its melodies.</p>
       </header>
+      <p id="panelHelper" class="panel-helper">
+        Tip: Selected operators and lines will glow below so you can confirm how your filters affect each station.
+      </p>
       <dl class="station-meta">
+        <div>
+          <dt>Served lines</dt>
+          <dd>
+            <div id="stationLines" class="meta-pill-group" role="list">—</div>
+          </dd>
+        </div>
+        <div>
+          <dt>Operators</dt>
+          <dd>
+            <div id="stationOperators" class="meta-pill-group" role="list">—</div>
+          </dd>
+        </div>
         <div>
           <dt>Platforms</dt>
           <dd id="stationPlatforms">—</dd>
-        </div>
-        <div>
-          <dt>Served lines</dt>
-          <dd id="stationLines">—</dd>
         </div>
       </dl>
       <section class="audio" aria-label="Station melodies">

--- a/Sites/jp-train-station/stations.json
+++ b/Sites/jp-train-station/stations.json
@@ -3,273 +3,447 @@
     "id": "tokyo",
     "name": "Tokyo",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Chuo Line", "Keihin-Tohoku Line", "Tokaido Shinkansen"],
+    "lines": [
+      "Yamanote Line",
+      "Chuo Line",
+      "Keihin-Tohoku Line",
+      "Tokaido Shinkansen"
+    ],
     "platforms": "1-10",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Yurakucho.mp3",
       "departure": "../yamanoteline/sounds/Tokyo.mp3"
     },
     "latitude": 35.681236,
-    "longitude": 139.767125
+    "longitude": 139.767125,
+    "operators": [
+      "JR East",
+      "JR Central"
+    ]
   },
   {
     "id": "kanda",
     "name": "Kanda",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Keihin-Tohoku Line", "Chuo Line"],
+    "lines": [
+      "Yamanote Line",
+      "Keihin-Tohoku Line",
+      "Chuo Line"
+    ],
     "platforms": "1-4",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Kanda.mp3",
       "departure": "../yamanoteline/sounds/Akihabara.mp3"
     },
     "latitude": 35.69169,
-    "longitude": 139.770883
+    "longitude": 139.770883,
+    "operators": [
+      "JR East"
+    ]
   },
   {
     "id": "akihabara",
     "name": "Akihabara",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Keihin-Tohoku Line", "Chuo-Sobu Line"],
+    "lines": [
+      "Yamanote Line",
+      "Keihin-Tohoku Line",
+      "Chuo-Sobu Line"
+    ],
     "platforms": "1-6",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Okachimachi.mp3",
       "departure": "../yamanoteline/sounds/Akihabara.mp3"
     },
     "latitude": 35.698683,
-    "longitude": 139.773243
+    "longitude": 139.773243,
+    "operators": [
+      "JR East"
+    ]
   },
   {
     "id": "ueno",
     "name": "Ueno",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Keihin-Tohoku Line", "Joban Line", "Tohoku Shinkansen"],
+    "lines": [
+      "Yamanote Line",
+      "Keihin-Tohoku Line",
+      "Joban Line",
+      "Tohoku Shinkansen"
+    ],
     "platforms": "1-11",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Ueno.mp3",
       "departure": "../yamanoteline/sounds/Nippori.mp3"
     },
     "latitude": 35.713768,
-    "longitude": 139.777254
+    "longitude": 139.777254,
+    "operators": [
+      "JR East"
+    ]
   },
   {
     "id": "ikebukuro",
     "name": "Ikebukuro",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Seibu Ikebukuro Line", "Tobu Tojo Line", "Marunouchi Line"],
+    "lines": [
+      "Yamanote Line",
+      "Seibu Ikebukuro Line",
+      "Tobu Tojo Line",
+      "Marunouchi Line"
+    ],
     "platforms": "1-8",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Mejiro.mp3",
       "departure": "../yamanoteline/sounds/Ikebukuro.mp3"
     },
     "latitude": 35.728926,
-    "longitude": 139.71038
+    "longitude": 139.71038,
+    "operators": [
+      "JR East",
+      "Seibu Railway",
+      "Tobu Railway",
+      "Tokyo Metro"
+    ]
   },
   {
     "id": "shinjuku",
     "name": "Shinjuku",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Chuo Line", "Saikyo Line", "Shonan-Shinjuku Line"],
+    "lines": [
+      "Yamanote Line",
+      "Chuo Line",
+      "Saikyo Line",
+      "Shonan-Shinjuku Line"
+    ],
     "platforms": "1-16",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Takadanobaba.mp3",
       "departure": "../yamanoteline/sounds/Shinjuku.mp3"
     },
     "latitude": 35.690921,
-    "longitude": 139.700258
+    "longitude": 139.700258,
+    "operators": [
+      "JR East"
+    ]
   },
   {
     "id": "shibuya",
     "name": "Shibuya",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Saikyo Line", "Ginza Line", "Hanzomon Line"],
+    "lines": [
+      "Yamanote Line",
+      "Saikyo Line",
+      "Ginza Line",
+      "Hanzomon Line"
+    ],
     "platforms": "1-6",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Harajuku.mp3",
       "departure": "../yamanoteline/sounds/Shibuya.mp3"
     },
     "latitude": 35.658034,
-    "longitude": 139.701636
+    "longitude": 139.701636,
+    "operators": [
+      "JR East",
+      "Tokyo Metro",
+      "Tokyu Corporation"
+    ]
   },
   {
     "id": "shinagawa",
     "name": "Shinagawa",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Keihin-Tohoku Line", "Tokaido Line", "Tokaido Shinkansen"],
+    "lines": [
+      "Yamanote Line",
+      "Keihin-Tohoku Line",
+      "Tokaido Line",
+      "Tokaido Shinkansen"
+    ],
     "platforms": "1-13",
     "melodies": {
       "arrival": "../yamanoteline/sounds/TakanawaGateway.mp3",
       "departure": "../yamanoteline/sounds/Shinagawa.mp3"
     },
     "latitude": 35.628471,
-    "longitude": 139.73876
+    "longitude": 139.73876,
+    "operators": [
+      "JR East",
+      "JR Central"
+    ]
   },
   {
     "id": "osaki",
     "name": "Osaki",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Saikyo Line", "Shonan-Shinjuku Line"],
+    "lines": [
+      "Yamanote Line",
+      "Saikyo Line",
+      "Shonan-Shinjuku Line"
+    ],
     "platforms": "1-4",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Osaki.mp3",
       "departure": "../yamanoteline/sounds/Gotanda.mp3"
     },
     "latitude": 35.619772,
-    "longitude": 139.728011
+    "longitude": 139.728011,
+    "operators": [
+      "JR East"
+    ]
   },
   {
     "id": "hamamatsucho",
     "name": "Hamamatsucho",
     "region": "Tokyo Prefecture",
-    "lines": ["Yamanote Line", "Keihin-Tohoku Line", "Tokyo Monorail"],
+    "lines": [
+      "Yamanote Line",
+      "Keihin-Tohoku Line",
+      "Tokyo Monorail"
+    ],
     "platforms": "1-6",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Hamamatsucho.mp3",
       "departure": "../yamanoteline/sounds/Shimbashi.mp3"
     },
     "latitude": 35.654321,
-    "longitude": 139.757654
+    "longitude": 139.757654,
+    "operators": [
+      "JR East",
+      "Tokyo Monorail"
+    ]
   },
   {
     "id": "yokohama",
     "name": "Yokohama",
     "region": "Kanagawa Prefecture",
-    "lines": ["Keihin-Tohoku Line", "Yokosuka Line", "Minatomirai Line", "Tokyu Toyoko Line"],
+    "lines": [
+      "Keihin-Tohoku Line",
+      "Yokosuka Line",
+      "Minatomirai Line",
+      "Tokyu Toyoko Line"
+    ],
     "platforms": "1-10",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Tamachi.mp3",
       "departure": "../yamanoteline/sounds/Osaki.mp3"
     },
     "latitude": 35.465833,
-    "longitude": 139.6225
+    "longitude": 139.6225,
+    "operators": [
+      "JR East",
+      "Tokyu Corporation",
+      "Minatomirai Railway"
+    ]
   },
   {
     "id": "nagoya",
     "name": "Nagoya",
     "region": "Aichi Prefecture",
-    "lines": ["Tokaido Line", "Chuo Main Line", "Sakura-dori Line", "Tokaido Shinkansen"],
+    "lines": [
+      "Tokaido Line",
+      "Chuo Main Line",
+      "Sakura-dori Line",
+      "Tokaido Shinkansen"
+    ],
     "platforms": "1-16",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Komagome.mp3",
       "departure": "../yamanoteline/sounds/Meguro.mp3"
     },
     "latitude": 35.170915,
-    "longitude": 136.881537
+    "longitude": 136.881537,
+    "operators": [
+      "JR Central",
+      "Nagoya Municipal Subway"
+    ]
   },
   {
     "id": "kyoto",
     "name": "Kyoto",
     "region": "Kyoto Prefecture",
-    "lines": ["Tokaido Shinkansen", "Sanin Main Line", "Kintetsu Kyoto Line"],
+    "lines": [
+      "Tokaido Shinkansen",
+      "Sanin Main Line",
+      "Kintetsu Kyoto Line"
+    ],
     "platforms": "0-34",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Sugamo.mp3",
       "departure": "../yamanoteline/sounds/Shinagawa.mp3"
     },
     "latitude": 34.985849,
-    "longitude": 135.758766
+    "longitude": 135.758766,
+    "operators": [
+      "JR West",
+      "Kintetsu Railway"
+    ]
   },
   {
     "id": "osaka",
     "name": "Osaka",
     "region": "Osaka Prefecture",
-    "lines": ["Osaka Loop Line", "Yamatoji Line", "Umeda Subway", "Hanwa Line"],
+    "lines": [
+      "Osaka Loop Line",
+      "Yamatoji Line",
+      "Umeda Subway",
+      "Hanwa Line"
+    ],
     "platforms": "1-11",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Tabata.mp3",
       "departure": "../yamanoteline/sounds/Ebisu.mp3"
     },
     "latitude": 34.702485,
-    "longitude": 135.495951
+    "longitude": 135.495951,
+    "operators": [
+      "JR West",
+      "Osaka Metro"
+    ]
   },
   {
     "id": "hiroshima",
     "name": "Hiroshima",
     "region": "Hiroshima Prefecture",
-    "lines": ["Sanyo Shinkansen", "Sanyo Main Line", "Kabe Line", "Hiroden"],
+    "lines": [
+      "Sanyo Shinkansen",
+      "Sanyo Main Line",
+      "Kabe Line",
+      "Hiroden"
+    ],
     "platforms": "1-9",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Mejiro.mp3",
       "departure": "../yamanoteline/sounds/Uguisudani.mp3"
     },
     "latitude": 34.397391,
-    "longitude": 132.475047
+    "longitude": 132.475047,
+    "operators": [
+      "JR West",
+      "Hiroshima Electric Railway"
+    ]
   },
   {
     "id": "hakata",
     "name": "Hakata",
     "region": "Fukuoka Prefecture",
-    "lines": ["Sanyo Shinkansen", "Kyushu Shinkansen", "Kagoshima Main Line"],
+    "lines": [
+      "Sanyo Shinkansen",
+      "Kyushu Shinkansen",
+      "Kagoshima Main Line"
+    ],
     "platforms": "1-16",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Harajuku.mp3",
       "departure": "../yamanoteline/sounds/Yoyogi.mp3"
     },
     "latitude": 33.5902,
-    "longitude": 130.4207
+    "longitude": 130.4207,
+    "operators": [
+      "JR West",
+      "JR Kyushu"
+    ]
   },
   {
     "id": "sapporo",
     "name": "Sapporo",
     "region": "Hokkaido Prefecture",
-    "lines": ["Hakodate Main Line", "Chitose Line", "Namboku Subway"],
+    "lines": [
+      "Hakodate Main Line",
+      "Chitose Line",
+      "Namboku Subway"
+    ],
     "platforms": "1-10",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Otsuka.mp3",
       "departure": "../yamanoteline/sounds/Nishinippori.mp3"
     },
     "latitude": 43.068661,
-    "longitude": 141.350755
+    "longitude": 141.350755,
+    "operators": [
+      "JR Hokkaido",
+      "Sapporo Municipal Subway"
+    ]
   },
   {
     "id": "sendai",
     "name": "Sendai",
     "region": "Miyagi Prefecture",
-    "lines": ["Tohoku Shinkansen", "Senseki Line", "Sendai Subway"],
+    "lines": [
+      "Tohoku Shinkansen",
+      "Senseki Line",
+      "Sendai Subway"
+    ],
     "platforms": "1-14",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Tokyo.mp3",
       "departure": "../yamanoteline/sounds/Okachimachi.mp3"
     },
     "latitude": 38.260833,
-    "longitude": 140.8825
+    "longitude": 140.8825,
+    "operators": [
+      "JR East",
+      "Sendai City Transportation Bureau"
+    ]
   },
   {
     "id": "kanazawa",
     "name": "Kanazawa",
     "region": "Ishikawa Prefecture",
-    "lines": ["Hokuriku Shinkansen", "IR Ishikawa Railway", "Hokuriku Main Line"],
+    "lines": [
+      "Hokuriku Shinkansen",
+      "IR Ishikawa Railway",
+      "Hokuriku Main Line"
+    ],
     "platforms": "1-7",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Tamachi.mp3",
       "departure": "../yamanoteline/sounds/Yurakucho.mp3"
     },
     "latitude": 36.578056,
-    "longitude": 136.648333
+    "longitude": 136.648333,
+    "operators": [
+      "JR West",
+      "IR Ishikawa Railway"
+    ]
   },
   {
     "id": "kagoshima-chuo",
     "name": "Kagoshima-Chuo",
     "region": "Kagoshima Prefecture",
-    "lines": ["Kyushu Shinkansen", "Ibusuki Makurazaki Line", "Kagoshima City Tram"],
+    "lines": [
+      "Kyushu Shinkansen",
+      "Ibusuki Makurazaki Line",
+      "Kagoshima City Tram"
+    ],
     "platforms": "1-13",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Ikebukuro.mp3",
       "departure": "../yamanoteline/sounds/Tamachi.mp3"
     },
     "latitude": 31.586,
-    "longitude": 130.561
+    "longitude": 130.561,
+    "operators": [
+      "JR Kyushu",
+      "Kagoshima City Transportation Bureau"
+    ]
   },
   {
     "id": "naha",
     "name": "Naha",
     "region": "Okinawa Prefecture",
-    "lines": ["Yui Rail"],
+    "lines": [
+      "Yui Rail"
+    ],
     "platforms": "1-2",
     "melodies": {
       "arrival": "../yamanoteline/sounds/Meguro.mp3",
       "departure": "../yamanoteline/sounds/Osaki.mp3"
     },
     "latitude": 26.2163,
-    "longitude": 127.679
+    "longitude": 127.679,
+    "operators": [
+      "Okinawa Urban Monorail"
+    ]
   }
 ]

--- a/Sites/jp-train-station/styles.css
+++ b/Sites/jp-train-station/styles.css
@@ -58,24 +58,37 @@ body {
 .map-overlay {
   position: fixed;
   inset-inline: clamp(1rem, 3vw, 2rem);
-  display: flex;
-  align-items: center;
+  display: grid;
   gap: 1rem;
-  padding: 0.85rem 1rem;
-  border-radius: 1rem;
+  padding: 1.15rem 1.35rem;
+  border-radius: 1.25rem;
   background: var(--bg-soft);
   backdrop-filter: blur(18px);
   box-shadow: var(--shadow);
   z-index: 5000;
+  max-height: min(90vh, 620px);
+  overflow-y: auto;
 }
 
 .map-overlay.top {
   top: clamp(1rem, 4vh, 2rem);
   inset-inline-start: 50%;
   transform: translateX(-50%);
-  flex-wrap: wrap;
-  justify-content: center;
-  max-width: min(960px, 92vw);
+  max-width: min(980px, 92vw);
+  width: min(960px, 92vw);
+}
+
+.overlay-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.overlay-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 .brand {
@@ -89,17 +102,17 @@ body {
 .search {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  flex: 1 1 360px;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .search input[type="search"] {
-  flex: 1 1 auto;
+  flex: 1 1 260px;
   min-width: 12rem;
-  padding: 0.65rem 0.9rem;
+  padding: 0.7rem 1rem;
   border-radius: 999px;
   border: 1px solid var(--border);
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(15, 23, 42, 0.9);
   color: var(--text-strong);
   font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -112,11 +125,105 @@ body {
 }
 
 .search-hint {
-  flex-basis: 100%;
   margin: 0;
   font-size: 0.85rem;
   color: var(--text-muted);
-  text-align: center;
+}
+
+.filter-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.1rem;
+  background: var(--bg-strong);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.filter-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.filter-helper {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.filter-groups {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.filter-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.filter-group label {
+  font-weight: 600;
+}
+
+.filter-search {
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text-strong);
+  font-size: 0.85rem;
+}
+
+.filter-search:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.filter-helper-text {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.filter-select {
+  width: 100%;
+  min-height: 9.5rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(2, 6, 23, 0.85);
+  color: var(--text-strong);
+  font-size: 0.9rem;
+  padding: 0.4rem;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.filter-select option {
+  padding: 0.25rem 0.35rem;
+}
+
+.filter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.filter-summary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.filter-buttons {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .btn {
@@ -217,6 +324,43 @@ body {
   color: var(--text-strong);
 }
 
+.meta-pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  min-height: 1.75rem;
+}
+
+.meta-pill-group:empty::after {
+  content: '—';
+  color: var(--text-muted);
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+.meta-pill.is-highlighted {
+  background: rgba(59, 130, 246, 0.3);
+  border-color: rgba(59, 130, 246, 0.55);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.panel-helper {
+  margin: -0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
 .audio {
   display: grid;
   gap: 0.75rem;
@@ -273,9 +417,39 @@ body {
 }
 
 @media (max-width: 720px) {
+  .map-overlay {
+    inset-inline: clamp(0.75rem, 4vw, 1.25rem);
+    padding: 1rem;
+    max-height: none;
+  }
+
   .map-overlay.top {
-    padding: 0.75rem 0.9rem;
-    gap: 0.75rem;
+    width: calc(100% - 1.5rem);
+  }
+
+  .overlay-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search {
+    gap: 0.5rem;
+  }
+
+  .search input[type="search"] {
+    flex: 1 1 100%;
+  }
+
+  .filter-panel {
+    padding: 0.85rem;
+  }
+
+  .filter-groups {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-select {
+    min-height: 8.5rem;
   }
 
   .station-panel {


### PR DESCRIPTION
## Summary
- expand the search overlay with operator and line filters plus contextual guidance
- restyle the overlay and station panel to support the new controls and metadata highlights
- build operator/line indexes in the app logic and enrich station data with operator listings

## Testing
- Manual verification via local HTTP server

------
https://chatgpt.com/codex/tasks/task_e_68e5ccbbc5f88328ba1cbdc513bcba32