### PR TITLE
Replace inline onclick nav button with anchor and update .ai-button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,7 @@
   <h1>Made With Only AI</h1>
   <p class="intro-text">I dont know how to code, and i dont know how to make a website, everything here including this has been made using only AI</p>
   <div class="button-group" role="navigation" aria-label="Site links">
-    <!-- Button that navigates to ./Sites/yamanoteline/index.html -->
-    <button class="ai-button" onclick="window.location.href='./Sites/yamanoteline/index.html'">
-      Go to Yamanote Line
-    </button>
+    <a class="ai-button" href="./Sites/yamanoteline/index.html">Go to Yamanote Line</a>
   </div>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -38,8 +38,10 @@ h3 {
 
 /* Single button styling */
 .ai-button {
+  display: inline-block;
   background: #ffd33d;
   color: #333;
+  text-decoration: none;
   font-size: 1.2rem;
   padding: 0.75rem 1.5rem;
   border: none;


### PR DESCRIPTION
### Motivation
- Replace the root page's inline `onclick` navigation with a semantic anchor and ensure the `.ai-button` class styles apply cleanly to both `<button>` and `<a>` elements.

### Description
- Replaced the `<button class="ai-button" onclick="window.location.href='./Sites/yamanoteline/index.html'">` with `<a class="ai-button" href="./Sites/yamanoteline/index.html">Go to Yamanote Line</a>` in `index.html`, and added `display: inline-block` and `text-decoration: none` to the `.ai-button` rule in `styles.css`.

### Testing
- Confirmed the change with `rg` searches that the inline `onclick` was removed and the anchor exists and that `styles.css` contains `display: inline-block` and `text-decoration: none`; attempted a Playwright screenshot to validate rendering but the environment could not load the page so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f01f96464832581cb7a8dd0440466)